### PR TITLE
Inner-slides polish, brand color logos, LinkedIn AI document titles

### DIFF
--- a/docs/reference/zernio-api.md
+++ b/docs/reference/zernio-api.md
@@ -81,6 +81,32 @@ See `src/app/api/webhooks/zernio/route.ts`. Zernio emits `post.scheduled`, `post
 
 ---
 
+## LinkedIn document title (PDF carousel)
+
+LinkedIn surfaces a visible filename on the post card / Featured tile (truncates near 55-60 visible chars). The wire format exposes a separate display title that overrides the filename, but our installed SDK (`@getlatedev/node@0.1.7`) does not type it. **Latest SDK is `0.2.100`** — the typings there add `LinkedInPlatformData.documentTitle?: string` and `MediaItem.title?: string`.
+
+**Resolution order (per Zernio docs surfaced via 0.2.100 typings):**
+
+1. `platforms[].platformSpecificData.documentTitle` (LinkedIn-only)
+2. `mediaItems[].title`
+3. `mediaItems[].filename`
+
+**Pass-through works on 0.1.7:** `createPost` body is serialised verbatim with `JSON.stringify` (`@hey-api/client-fetch`), so adding `documentTitle` to a `Record<string, unknown>` PSD object reaches Zernio. We do this at every LinkedIn carousel publish/sync site:
+
+```ts
+const psd: Record<string, unknown> = {};
+if (post.firstComment) psd.firstComment = post.firstComment;
+if (platform === "linkedin" && documentTitle) {
+  psd.documentTitle = documentTitle;  // smuggled — not in 0.1.7 types
+}
+```
+
+**Source of the title:** AI-generated fresh per publish via `prepareLinkedInPdfMetadata()` in `src/lib/pdf-carousel.ts`. Prompt explicitly excludes brand name, issue number, and post-type labels — output is a 6-10 word magazine-cover line that complements (not duplicates) the post body. Falls back to the campaign description's first sentence if the Anthropic call fails.
+
+**SDK upgrade ticket:** tracked separately — once typed via `0.2.100` we can drop the cast.
+
+---
+
 ## Ads API (live-probed, gated by add-on)
 
 **Status:** Zernio shipped a paid-ads API in April 2026. We have **not integrated it yet**. The current `LATE_API_KEY` (Dominate/AppSumo plan) does **not** have access — every `/v1/ads/*` endpoint returns `HTTP 403 {"error":"Ads add-on required"}`. Activating ads requires purchasing the Ads Add-On as a billing line item (separate from the base plan); the Dominate/lifetime plan does not include it.

--- a/scripts/preview-last-linkedin-pdf.mjs
+++ b/scripts/preview-last-linkedin-pdf.mjs
@@ -1,0 +1,193 @@
+/**
+ * Preview the LinkedIn document title + PDF filename that would be generated
+ * for a LinkedIn carousel post. Shows before-vs-after vs. the legacy slug.
+ *
+ * Usage:
+ *   npx tsx scripts/preview-last-linkedin-pdf.mjs                      # most recent carousel
+ *   npx tsx scripts/preview-last-linkedin-pdf.mjs "Issue No.75"        # matches campaign name substring
+ *   npx tsx scripts/preview-last-linkedin-pdf.mjs --post recXXXXXXXX   # specific post id
+ */
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const envFile = await fs.readFile(path.join(process.cwd(), ".env.local"), "utf8");
+for (const line of envFile.split("\n")) {
+  const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+  if (m && !process.env[m[1]]) process.env[m[1]] = m[2];
+}
+
+const BASE = process.env.AIRTABLE_BASE_ID;
+const KEY = process.env.AIRTABLE_API_KEY;
+if (!BASE || !KEY) throw new Error("Missing Airtable env");
+
+async function airtable(query) {
+  const res = await fetch(`https://api.airtable.com/v0/${BASE}/${query}`, {
+    headers: { Authorization: `Bearer ${KEY}` },
+  });
+  if (!res.ok) throw new Error(`Airtable ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+const args = process.argv.slice(2);
+const postIdArgIdx = args.indexOf("--post");
+const explicitPostId = postIdArgIdx >= 0 ? args[postIdArgIdx + 1] : null;
+const searchTerm = !explicitPostId && args[0] && !args[0].startsWith("--")
+  ? args[0]
+  : null;
+
+let post = null;
+
+if (explicitPostId) {
+  post = await airtable(`Posts/${explicitPostId}`);
+} else if (searchTerm) {
+  // Find a LinkedIn carousel post in a campaign whose name contains the search term.
+  const campaignFilter = encodeURIComponent(
+    `FIND(LOWER("${searchTerm}"), LOWER({Name}))`
+  );
+  const camp = await airtable(`Campaigns?filterByFormula=${campaignFilter}&maxRecords=10`);
+  if (!camp.records.length) {
+    console.error(`No campaign matched "${searchTerm}".`);
+    process.exit(1);
+  }
+  console.log(`Matched ${camp.records.length} campaign(s) for "${searchTerm}":`);
+  for (const c of camp.records) console.log(`  ${c.id}  ${c.fields.Name}`);
+
+  // For each matched campaign, scan that campaign's posts (paginated) and find a LinkedIn one.
+  let fallbackPost = null;
+  const campaignIds = new Set(camp.records.map((c) => c.id));
+
+  // List all posts for these campaigns by paginating until exhausted.
+  // (Linked-record FIND() inside filterByFormula is unreliable; client-filter instead.)
+  let offset = "";
+  outer: for (let page = 0; page < 30; page++) {
+    const params = new URLSearchParams({
+      "filterByFormula": `{Platform} = "LinkedIn"`,
+      "sort[0][field]": "Scheduled Date",
+      "sort[0][direction]": "desc",
+      "pageSize": "100",
+    });
+    if (offset) params.set("offset", offset);
+    const data = await airtable(`Posts?${params.toString()}`);
+    for (const r of data.records) {
+      const linked = r.fields.Campaign || [];
+      if (!linked.some((id) => campaignIds.has(id))) continue;
+      const mediaUrls = r.fields["Media URLs"];
+      const count = mediaUrls
+        ? mediaUrls.split(/\r?\n/).filter((s) => s.trim().length > 0).length
+        : 0;
+      const userPdf = r.fields["Carousel PDF URL"];
+      if (count >= 2 || userPdf) {
+        post = r;
+        post._mediaCount = count;
+        post._userPdf = !!userPdf;
+        break outer;
+      }
+      if (!fallbackPost) {
+        fallbackPost = r;
+        fallbackPost._mediaCount = count;
+      }
+    }
+    if (!data.offset) break;
+    offset = data.offset;
+  }
+
+  if (!post && fallbackPost) {
+    post = fallbackPost;
+    console.log("(no carousel — using single-image LinkedIn post for the title preview)");
+  }
+  if (!post) {
+    console.error(`Found campaigns but no LinkedIn post in them.`);
+    process.exit(1);
+  }
+} else {
+  // Most recent LinkedIn carousel anywhere
+  const filter = encodeURIComponent(
+    'AND({Platform} = "LinkedIn", {Zernio Post ID} != "")'
+  );
+  const url =
+    `Posts?filterByFormula=${filter}` +
+    `&sort%5B0%5D%5Bfield%5D=Scheduled%20Date&sort%5B0%5D%5Bdirection%5D=desc` +
+    `&maxRecords=8`;
+  const { records } = await airtable(url);
+  if (records.length === 0) {
+    console.log("No published LinkedIn posts found.");
+    process.exit(0);
+  }
+  for (const r of records) {
+    const mediaUrls = r.fields["Media URLs"];
+    const count = mediaUrls
+      ? mediaUrls.split(/\r?\n/).filter((s) => s.trim().length > 0).length
+      : 0;
+    const userPdf = r.fields["Carousel PDF URL"];
+    if (count >= 2 || userPdf) {
+      post = r;
+      post._mediaCount = count;
+      post._userPdf = !!userPdf;
+      break;
+    }
+  }
+  if (!post) {
+    post = records[0];
+    post._mediaCount = 1;
+  }
+}
+
+const campaignId = post.fields.Campaign?.[0];
+if (!campaignId) {
+  console.error("Post has no campaign linked.");
+  process.exit(1);
+}
+const campaign = await airtable(`Campaigns/${campaignId}`);
+const brandId = campaign.fields.Brand?.[0];
+const brand = brandId ? await airtable(`Brands/${brandId}`) : null;
+
+console.log(`\n=== Most recent LinkedIn carousel post ===`);
+console.log(`Post ID:       ${post.id}`);
+console.log(`Scheduled:     ${post.fields["Scheduled Date"] || "(none)"}`);
+console.log(`Status:        ${post.fields.Status}`);
+console.log(`Media items:   ${post._mediaCount}${post._userPdf ? " (user-supplied PDF)" : ""}`);
+console.log(`Zernio post:   ${post.fields["Zernio Post ID"] || "(none)"}`);
+console.log(`\nCampaign:      ${campaign.fields.Name}`);
+console.log(`Brand:         ${brand?.fields.Name || "(none)"}`);
+console.log(
+  `\nPost content (first 200 chars):\n  ${(post.fields.Content || "").slice(0, 200).replace(/\n/g, "\n  ")}`
+);
+console.log(
+  `\nCampaign description (first 300 chars):\n  ${(campaign.fields.Description || "").slice(0, 300).replace(/\n/g, "\n  ")}`
+);
+console.log(
+  `\nEditorial direction (first 300 chars):\n  ${(campaign.fields["Editorial Direction"] || "").slice(0, 300).replace(/\n/g, "\n  ")}`
+);
+
+const { prepareLinkedInPdfMetadata } = await import("../src/lib/pdf-carousel.ts");
+
+console.log(`\n=== Generating new title (Claude Sonnet 4.6) ===`);
+const t0 = Date.now();
+const meta = await prepareLinkedInPdfMetadata({
+  campaignDescription: campaign.fields.Description || "",
+  editorialDirection: campaign.fields["Editorial Direction"] || "",
+  postContent: post.fields.Content || "",
+  brand: { anthropicApiKeyLabel: brand?.fields["Anthropic API Key Label"] || null },
+});
+const ms = Date.now() - t0;
+console.log(`\nNEW documentTitle:  "${meta.documentTitle}"  (${meta.documentTitle.length} chars, ${ms}ms)`);
+console.log(`NEW filename:        "${meta.filename}"  (${meta.filename.length} chars)`);
+
+// For comparison: what the OLD slugified filename would have been
+function legacySlug(name, postId) {
+  const slug = (name || "carousel")
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase()
+    .slice(0, 60)
+    .replace(/-+$/, "");
+  const suffix = postId ? `-${postId.slice(-6).toLowerCase()}` : "";
+  const head =
+    slug.length + suffix.length > 60
+      ? slug.slice(0, Math.max(1, 60 - suffix.length)).replace(/-+$/, "")
+      : slug;
+  return `${head}${suffix}.pdf`;
+}
+console.log(`\nOLD filename (legacy slug, for comparison): "${legacySlug(campaign.fields.Name, post.id)}"`);

--- a/scripts/probe-linkedin-document-title.mjs
+++ b/scripts/probe-linkedin-document-title.mjs
@@ -1,0 +1,60 @@
+/**
+ * Probe `prepareLinkedInPdfMetadata` against representative campaign/post data.
+ * Prints the AI-generated documentTitle and the matching filename so we can
+ * eyeball that the output is human-readable and within the 55-char budget.
+ *
+ * Usage:  node scripts/probe-linkedin-document-title.mjs
+ */
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const envFile = await fs.readFile(path.join(process.cwd(), ".env.local"), "utf8");
+for (const line of envFile.split("\n")) {
+  const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+  if (m && !process.env[m[1]]) process.env[m[1]] = m[2];
+}
+
+// We import via tsx so TS source resolves. Fallback: dynamic require of compiled.
+const { prepareLinkedInPdfMetadata } = await import("../src/lib/pdf-carousel.ts").catch(
+  async () => await import("../src/lib/pdf-carousel.js")
+);
+
+const cases = [
+  {
+    label: "The Intersect — wrenches/AI-art issue",
+    campaignDescription:
+      "An issue exploring how AI image generation is reshaping artistic labor: wrenches, paper, and waste — examining what stays organic when machines can produce any image in seconds.",
+    editorialDirection:
+      "Be skeptical of hype. Highlight the artists who refuse to be replaced. Conversational, occasionally biting.",
+    postContent:
+      "AI can generate any image in seconds. So why are artists still showing up to studios with paint-stained hands?",
+  },
+  {
+    label: "Newsletter — long boilerplate name",
+    campaignDescription:
+      "How a curator's role is changing in a year of museum cuts. Profiles five practitioners adapting to shrinking budgets without abandoning rigor.",
+    editorialDirection: "Empathetic but grounded. Real numbers, real names.",
+    postContent:
+      "Museum budgets are being slashed. Five curators on what they're letting go of — and what they refuse to.",
+  },
+  {
+    label: "Empty fallback (no description, no AI)",
+    campaignDescription: "",
+    editorialDirection: "",
+    postContent: "",
+  },
+];
+
+for (const c of cases) {
+  process.stdout.write(`\n--- ${c.label} ---\n`);
+  const t0 = Date.now();
+  const meta = await prepareLinkedInPdfMetadata({
+    campaignDescription: c.campaignDescription,
+    editorialDirection: c.editorialDirection,
+    postContent: c.postContent,
+    brand: null,
+  });
+  const ms = Date.now() - t0;
+  process.stdout.write(`  documentTitle: "${meta.documentTitle}" (${meta.documentTitle.length} chars, ${ms}ms)\n`);
+  process.stdout.write(`  filename:      "${meta.filename}" (${meta.filename.length} chars)\n`);
+}

--- a/scripts/verify-dynamic-pdf.mjs
+++ b/scripts/verify-dynamic-pdf.mjs
@@ -1,0 +1,78 @@
+import { loadCreds, loginPuppeteerCookies } from "./lib/puppeteer-auth.mjs";
+import { writeFile } from "node:fs/promises";
+
+// End-to-end verifier for the dynamic-inner-slides PDF flow.
+// Renders an LI carousel for N stories (where N is uneven so we exercise the
+// orphan + subscribe cell), then an IG carousel of the same stories.
+//
+//   node scripts/verify-dynamic-pdf.mjs <numStories>
+
+const N = Number(process.argv[2] ?? 5);
+const BASE = "http://localhost:3025";
+const HERO =
+  "https://njhagrdezivhku5m.public.blob.vercel-storage.com/cover-generator/issue-76-lead.jpg";
+const COLORS = ["333", "0a4", "a04", "04a", "707", "0aa", "a70", "707", "555"];
+const stories = Array.from({ length: N }, (_, i) => ({
+  title: `Story ${i + 1}`,
+  imageUrl: `https://placehold.co/800x800/${COLORS[i % COLORS.length]}/fff.png?text=Story+${i + 1}`,
+}));
+const innerCount = Math.max(1, Math.ceil(N / 2));
+const innerSlides = Array.from({ length: innerCount }, () => ({
+  numeral: { fontSize: 245, dx: -29, dy: -48 },
+  bgColor: null,
+  bgLightness: 0,
+  taglineFs: 50,
+  logoLeft: true,
+}));
+
+const creds = loadCreds();
+const cookies = await loginPuppeteerCookies(BASE, creds);
+const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+
+async function downloadPdf(format) {
+  const innerKeys = Array.from({ length: innerCount }, (_, i) => `i${i}`);
+  const slides =
+    format === "li" ? ["A", ...innerKeys] : ["A", ...innerKeys, "C"];
+  const sp = new URLSearchParams();
+  sp.set("slides", slides.join(","));
+  sp.set("fmt", format);
+  sp.set("hero", HERO);
+  sp.set("subs", "theintersect.art");
+  sp.set("n", "75");
+  sp.set("dt", "APRIL 28, 2026");
+  sp.set("br", "THE INTERSECT");
+  sp.set("bln", "The Intersect");
+  sp.set("tg", "Wrenches, paper, waste — organic holds its ground.");
+  sp.set("sp", JSON.stringify(stories));
+  sp.set("is", JSON.stringify(innerSlides));
+  sp.set("ax", "50");
+  sp.set("ay", "50");
+  sp.set("az", "1");
+  sp.set("bl", "0");
+  sp.set("bb", "0");
+  sp.set("cx", "50");
+  sp.set("cy", "50");
+  sp.set("cz", "1");
+  sp.set("tafs", "52");
+  sp.set("tcfs", "56");
+  sp.set("s1nl", "1");
+  sp.set("s1no", "18");
+
+  const url = `${BASE}/api/tools/download-pdf?${sp.toString()}`;
+  console.log(`\n=== ${format.toUpperCase()} (${N} stories → ${slides.length} slides: ${slides.join(",")}) ===`);
+  console.log(`fetching… (~${slides.length * 5}s)`);
+  const start = Date.now();
+  const resp = await fetch(url, { headers: { Cookie: cookieHeader } });
+  console.log(`status: ${resp.status} in ${((Date.now() - start) / 1000).toFixed(1)}s`);
+  if (!resp.ok) {
+    console.log(`error body: ${(await resp.text()).slice(0, 400)}`);
+    return;
+  }
+  const buf = Buffer.from(await resp.arrayBuffer());
+  const out = `/tmp/dynamic-${format}-${N}story.pdf`;
+  await writeFile(out, buf);
+  console.log(`saved: ${out} (${(buf.length / 1024).toFixed(0)} KB)`);
+}
+
+await downloadPdf("li");
+await downloadPdf("ig");

--- a/src/app/api/brands/[id]/logo/route.ts
+++ b/src/app/api/brands/[id]/logo/route.ts
@@ -6,20 +6,25 @@ import { updateRecord, getRecord } from "@/lib/airtable/client";
 import { isBlobUrl } from "@/lib/blob-storage";
 
 /**
- * Logo upload endpoint — supports four slots per brand:
- *   - light-square / dark-square — square (1:1) logos
- *   - light-rect / dark-rect     — rectangular/wordmark logos
+ * Logo upload endpoint — six slots per brand:
+ *   - color-square / light-square / dark-square — square (1:1) logos
+ *   - color-rect   / light-rect   / dark-rect   — rectangular/wordmark logos
  *
- * "light" / "dark" refers to the BACKGROUND the logo is placed on:
+ * For the transparent variants, "light" / "dark" refers to the BACKGROUND
+ * the logo is intended to sit on:
  *   - light-* = logo for light backgrounds (dark/black logo art)
  *   - dark-*  = logo for dark backgrounds (white/light logo art)
+ *
+ * The color-* variants are full-color marks usable on either surface.
  *
  * Each slot maps to one Airtable URL field.
  */
 
 const SLOT_TO_FIELD = {
+  "color-square": "Logo Color Square",
   "light-square": "Logo Transparent Dark", // logo art is DARK, lives on LIGHT bg
   "dark-square": "Logo Transparent Light", // logo art is LIGHT, lives on DARK bg
+  "color-rect": "Logo Color Rectangular",
   "light-rect": "Logo Rectangular Light", // wordmark for use OVER light bg
   "dark-rect": "Logo Rectangular Dark", // wordmark for use OVER dark bg
 } as const;
@@ -98,6 +103,8 @@ interface BrandLogoFields {
   "Logo Transparent Dark"?: string;
   "Logo Rectangular Light"?: string;
   "Logo Rectangular Dark"?: string;
+  "Logo Color Square"?: string;
+  "Logo Color Rectangular"?: string;
 }
 
 export async function POST(
@@ -110,7 +117,10 @@ export async function POST(
 
     if (!slot || !(slot in SLOT_TO_FIELD)) {
       return NextResponse.json(
-        { error: "Invalid slot. Expected: light-square | dark-square | light-rect | dark-rect" },
+        {
+          error:
+            "Invalid slot. Expected one of: color-square | light-square | dark-square | color-rect | light-rect | dark-rect",
+        },
         { status: 400 }
       );
     }

--- a/src/app/api/brands/route.ts
+++ b/src/app/api/brands/route.ts
@@ -43,6 +43,7 @@ interface BrandFields {
   "Lnk.Bio Username": string;
   "Lnk.Bio Client ID Label": string;
   "Lnk.Bio Client Secret Label": string;
+  "Subscribe URL": string;
   Status: "Active" | "Inactive";
 }
 
@@ -93,6 +94,7 @@ function mapBrand(r: { id: string; fields: BrandFields }): Brand {
     lnkBioUsername: r.fields["Lnk.Bio Username"] || null,
     lnkBioClientIdLabel: r.fields["Lnk.Bio Client ID Label"] || null,
     lnkBioClientSecretLabel: r.fields["Lnk.Bio Client Secret Label"] || null,
+    subscribeUrl: r.fields["Subscribe URL"] || "",
     status: r.fields.Status || "Active",
   };
 }
@@ -156,6 +158,7 @@ export async function PATCH(request: NextRequest) {
       logoTransparentDark: "Logo Transparent Dark",
       logoRectangularLight: "Logo Rectangular Light",
       logoRectangularDark: "Logo Rectangular Dark",
+      subscribeUrl: "Subscribe URL",
       status: "Status",
     };
 

--- a/src/app/api/brands/route.ts
+++ b/src/app/api/brands/route.ts
@@ -35,6 +35,8 @@ interface BrandFields {
   "Logo Transparent Dark": string;
   "Logo Rectangular Light": string;
   "Logo Rectangular Dark": string;
+  "Logo Color Square": string;
+  "Logo Color Rectangular": string;
   "Tone Dimensions": string;
   "Tone Notes": string;
   "Default Voice Intensity": number;
@@ -86,6 +88,8 @@ function mapBrand(r: { id: string; fields: BrandFields }): Brand {
     logoTransparentDark: r.fields["Logo Transparent Dark"] || null,
     logoRectangularLight: r.fields["Logo Rectangular Light"] || null,
     logoRectangularDark: r.fields["Logo Rectangular Dark"] || null,
+    logoColorSquare: r.fields["Logo Color Square"] || null,
+    logoColorRect: r.fields["Logo Color Rectangular"] || null,
     toneDimensions: parseToneDimensions(r.fields["Tone Dimensions"]),
     toneNotes: r.fields["Tone Notes"] || undefined,
     defaultVoiceIntensity: r.fields["Default Voice Intensity"] ?? undefined,
@@ -158,6 +162,8 @@ export async function PATCH(request: NextRequest) {
       logoTransparentDark: "Logo Transparent Dark",
       logoRectangularLight: "Logo Rectangular Light",
       logoRectangularDark: "Logo Rectangular Dark",
+      logoColorSquare: "Logo Color Square",
+      logoColorRect: "Logo Color Rectangular",
       subscribeUrl: "Subscribe URL",
       status: "Status",
     };

--- a/src/app/api/campaigns/[id]/generate/route.ts
+++ b/src/app/api/campaigns/[id]/generate/route.ts
@@ -3,6 +3,7 @@ import { getRecord, updateRecord, listRecords, createRecord } from "@/lib/airtab
 import { getUserBrandAccess, hasCampaignAccess } from "@/lib/brand-access";
 import { getCampaignTypeRule, getGenerationRules } from "@/lib/airtable/campaign-type-rules";
 import { scrapeBlogPost, scrapeNewsletter, scrapeEvent, scrapeExhibition, scrapeSupplemental, extractArtistMetadata, type ContentSection, type ScrapedEventBlogData, type ScrapedExhibitionBlogData } from "@/lib/firecrawl";
+import { mirrorRemoteImageToBlob } from "@/lib/blob-storage";
 import { generatePosts, resolveAnthropicConfig } from "@/lib/anthropic";
 import {
   SYSTEM_PROMPT,
@@ -635,11 +636,23 @@ export async function POST(
         const artistMeta = isArtistProfile ? extractArtistMetadata(blogData) : null;
         const artistCampaignName = artistMeta?.campaignLabel || null;
 
+        // Mirror the scraped hero into Vercel Blob so the campaign's
+        // Image URL is permanent. CMS-served URLs (Substack, Airtable-backed
+        // sites) can expire or move; saving the raw scrape URL leaves the
+        // campaign thumbnail and downstream "use as social media campaign
+        // hero" flows fragile. mirrorRemoteImageToBlob is a no-op when the
+        // URL is already on Blob and returns "" on fetch failure so the
+        // existing fall-through (no Image URL written) still applies.
+        const mirroredOgImageUrl =
+          !fields["Image URL"] && ogImageUrl
+            ? await mirrorRemoteImageToBlob(ogImageUrl, "campaigns", campaignId)
+            : "";
+
         await updateRecord("Campaigns", campaignId, {
           ...(isAdditive ? {} : { Status: "Generating" }),
           "Scraped Content": blogData.content.slice(0, 10000),
           "Scraped Images": JSON.stringify(blogData.images),
-          ...(!fields["Image URL"] && ogImageUrl ? { "Image URL": ogImageUrl } : {}),
+          ...(mirroredOgImageUrl ? { "Image URL": mirroredOgImageUrl } : {}),
           ...(!fields.Description && blogData.title ? { Description: blogData.title } : {}),
           ...(isQuickPostCampaign && blogData.title ? { Name: `Quick Post: ${blogData.title}` } : {}),
           // Artist Profile: set descriptive campaign name and store artist handle

--- a/src/app/api/campaigns/[id]/image/route.ts
+++ b/src/app/api/campaigns/[id]/image/route.ts
@@ -28,12 +28,10 @@ export async function POST(
     const buffer = Buffer.from(bytes);
     const contentType = file.type || "image/jpeg";
 
-    // Delete previous Blob image if one exists
-    const existing = await getRecord<{ "Image URL": string }>("Campaigns", id);
-    const existingUrl = existing.fields["Image URL"];
-    if (existingUrl && isBlobUrl(existingUrl)) {
-      await deleteImage(existingUrl).catch(() => {});
-    }
+    // NOTE: Do NOT eagerly delete the previous Image URL Blob here. That
+    // pattern was destructive once the carousel-append flow started keeping
+    // the prior URL alive in the post's media array. Orphan cleanup is
+    // handled separately by cleanupCampaignPosts.
 
     // Upload to Vercel Blob
     const imageUrl = await uploadImage("campaigns", id, buffer, contentType);

--- a/src/app/api/campaigns/[id]/publish/route.ts
+++ b/src/app/api/campaigns/[id]/publish/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getRecord, updateRecord, listRecords } from "@/lib/airtable/client";
 import { getUserBrandAccess, hasCampaignAccess } from "@/lib/brand-access";
 import { createBrandClient } from "@/lib/late-api/client";
-import { assembleCarouselPDF } from "@/lib/pdf-carousel";
+import { assembleCarouselPDF, prepareLinkedInPdfMetadata } from "@/lib/pdf-carousel";
 import { ensureAspectRatio } from "@/lib/image-crop";
 import { parseMediaItems } from "@/lib/media-items";
 import { SLIDE_PLATFORMS } from "@/lib/platform-constants";
@@ -11,6 +11,8 @@ interface CampaignFields {
   Name: string;
   Brand: string[];
   Status: string;
+  Description?: string;
+  "Editorial Direction"?: string;
 }
 
 interface BrandFields {
@@ -18,6 +20,7 @@ interface BrandFields {
   "Zernio Profile ID": string;
   Timezone?: string;
   "Outpaint Instead of Crop"?: boolean;
+  "Anthropic API Key Label"?: string;
 }
 
 interface PostFields {
@@ -157,11 +160,19 @@ export async function POST(
 
         // LinkedIn carousel: multiple images → assemble PDF document (with captions)
         let mediaItems: Array<{ type: "image" | "document"; url: string; filename?: string }>;
+        let linkedInDocumentTitle: string | undefined;
         if (platform === "linkedin" && imageUrls.length > 1) {
           const pdfBuffer = await assembleCarouselPDF(postMediaItems);
+          const meta = await prepareLinkedInPdfMetadata({
+            campaignDescription: campaign.fields.Description,
+            editorialDirection: campaign.fields["Editorial Direction"],
+            postContent: post.fields.Content,
+            brand: { anthropicApiKeyLabel: brandRecord.fields["Anthropic API Key Label"] || null },
+          });
+          linkedInDocumentTitle = meta.documentTitle;
           const { data: presignData } = await client.media.getMediaPresignedUrl({
             body: {
-              filename: `${(campaign.fields.Name || "Carousel").slice(0, 60)}.pdf`,
+              filename: meta.filename,
               contentType: "application/pdf",
               size: pdfBuffer.length,
             },
@@ -172,8 +183,7 @@ export async function POST(
               body: new Uint8Array(pdfBuffer),
               headers: { "Content-Type": "application/pdf" },
             });
-            const pdfDisplayName = `${(campaign.fields.Name || "Carousel").slice(0, 60)}.pdf`;
-            mediaItems = [{ type: "document", url: presignData.publicUrl!, filename: pdfDisplayName }];
+            mediaItems = [{ type: "document", url: presignData.publicUrl!, filename: meta.filename }];
           } else {
             // Fallback to individual images if presign fails
             mediaItems = imageUrls.map((url) => ({ type: "image" as const, url }));
@@ -191,10 +201,13 @@ export async function POST(
           accountId: (account as { _id: string })._id,
         };
 
-        if (post.fields["First Comment"]) {
-          platformEntry.platformSpecificData = {
-            firstComment: post.fields["First Comment"],
-          };
+        const psd: Record<string, unknown> = {};
+        if (post.fields["First Comment"]) psd.firstComment = post.fields["First Comment"];
+        if (platform === "linkedin" && linkedInDocumentTitle) {
+          psd.documentTitle = linkedInDocumentTitle;
+        }
+        if (Object.keys(psd).length > 0) {
+          platformEntry.platformSpecificData = psd;
         }
 
         const createBody: Record<string, unknown> = {

--- a/src/app/api/campaigns/[id]/schedule/route.ts
+++ b/src/app/api/campaigns/[id]/schedule/route.ts
@@ -3,7 +3,7 @@ import { getRecord, updateRecord, listRecords } from "@/lib/airtable/client";
 import { getUserBrandAccess, hasCampaignAccess } from "@/lib/brand-access";
 import { schedulePostsAlgorithm, previewSchedule } from "@/lib/scheduling";
 import { createBrandClient } from "@/lib/late-api/client";
-import { assembleCarouselPDF } from "@/lib/pdf-carousel";
+import { assembleCarouselPDF, prepareLinkedInPdfMetadata } from "@/lib/pdf-carousel";
 import { ensureAspectRatio } from "@/lib/image-crop";
 import { parseMediaItems } from "@/lib/media-items";
 import { SLIDE_PLATFORMS } from "@/lib/platform-constants";
@@ -18,6 +18,8 @@ interface CampaignFields {
   "Event Date": string;
   "Start Date": string;
   "Platform Cadence": string;
+  Description?: string;
+  "Editorial Direction"?: string;
 }
 
 interface PostFields {
@@ -46,6 +48,7 @@ interface BrandFields {
   "Lnk.Bio Client ID Label"?: string;
   "Lnk.Bio Client Secret Label"?: string;
   "Outpaint Instead of Crop"?: boolean;
+  "Anthropic API Key Label"?: string;
 }
 
 /** Map Airtable platform names to Zernio platform IDs */
@@ -288,11 +291,19 @@ export async function POST(
 
         // LinkedIn carousel: multiple images → PDF
         let mediaItems: Array<{ type: "image" | "document"; url: string; filename?: string }>;
+        let linkedInDocumentTitle: string | undefined;
         if (platform === "linkedin" && imageUrls.length > 1) {
           const pdfBuffer = await assembleCarouselPDF(postMediaItems);
+          const meta = await prepareLinkedInPdfMetadata({
+            campaignDescription: campaign.fields.Description,
+            editorialDirection: campaign.fields["Editorial Direction"],
+            postContent: post.fields.Content,
+            brand: { anthropicApiKeyLabel: brandRecord.fields["Anthropic API Key Label"] || null },
+          });
+          linkedInDocumentTitle = meta.documentTitle;
           const { data: presignData } = await client.media.getMediaPresignedUrl({
             body: {
-              filename: `${(campaign.fields.Name || "Carousel").slice(0, 60)}.pdf`,
+              filename: meta.filename,
               contentType: "application/pdf",
               size: pdfBuffer.length,
             },
@@ -303,7 +314,7 @@ export async function POST(
               body: new Uint8Array(pdfBuffer),
               headers: { "Content-Type": "application/pdf" },
             });
-            mediaItems = [{ type: "document", url: presignData.publicUrl!, filename: `${(campaign.fields.Name || "Carousel").slice(0, 60)}.pdf` }];
+            mediaItems = [{ type: "document", url: presignData.publicUrl!, filename: meta.filename }];
           } else {
             mediaItems = imageUrls.map((url) => ({ type: "image" as const, url }));
           }
@@ -320,10 +331,13 @@ export async function POST(
           accountId: (account as { _id: string })._id,
         };
 
-        if (post.fields["First Comment"]) {
-          platformEntry.platformSpecificData = {
-            firstComment: post.fields["First Comment"],
-          };
+        const psd: Record<string, unknown> = {};
+        if (post.fields["First Comment"]) psd.firstComment = post.fields["First Comment"];
+        if (platform === "linkedin" && linkedInDocumentTitle) {
+          psd.documentTitle = linkedInDocumentTitle;
+        }
+        if (Object.keys(psd).length > 0) {
+          platformEntry.platformSpecificData = psd;
         }
 
         const createBody: Record<string, unknown> = {

--- a/src/app/api/campaigns/route.ts
+++ b/src/app/api/campaigns/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { listRecords, createRecord, getRecord } from "@/lib/airtable/client";
+import { listRecords, createRecord, updateRecord, getRecord } from "@/lib/airtable/client";
 import { getUserBrandAccess, hasCampaignAccess, hasBrandAccess } from "@/lib/brand-access";
+import { mirrorRemoteImageToBlob } from "@/lib/blob-storage";
 import type { Campaign, PlatformCadenceConfig } from "@/lib/airtable/types";
 
 interface CampaignFields {
@@ -200,6 +201,30 @@ export async function POST(request: NextRequest) {
       ...(cadenceJson ? { "Platform Cadence": cadenceJson } : {}),
       ...(body.voiceIntensity != null ? { Tone: body.voiceIntensity } : {}),
     });
+
+    // Mirror the scraped og:image into Vercel Blob so the campaign's
+    // Image URL is permanent. Some CMS-served URLs (Substack, Airtable-
+    // backed sites) expire or rotate; saving the raw scrape URL leaves
+    // the thumbnail and downstream "use as social media campaign hero"
+    // fragile. Done after createRecord so the entityId for the Blob
+    // path matches the new campaign. Fire-and-forget — the response
+    // doesn't wait on it; the row gets patched once the mirror finishes.
+    if (metadata.imageUrl) {
+      mirrorRemoteImageToBlob(metadata.imageUrl, "campaigns", record.id)
+        .then((mirrored) => {
+          if (mirrored) {
+            return updateRecord("Campaigns", record.id, {
+              "Image URL": mirrored,
+            });
+          }
+        })
+        .catch((e) =>
+          console.warn(
+            `[campaigns POST] mirror failed for ${record.id}:`,
+            (e as Error).message,
+          ),
+        );
+    }
 
     return NextResponse.json({ campaign: record }, { status: 201 });
   } catch (error) {

--- a/src/app/api/posts/[id]/image/route.ts
+++ b/src/app/api/posts/[id]/image/route.ts
@@ -29,12 +29,12 @@ export async function POST(
     const buffer = Buffer.from(bytes);
     const contentType = file.type || "image/jpeg";
 
-    // Delete previous Blob image if one exists
-    const existing = await getRecord<{ "Image URL": string }>("Posts", id);
-    const existingUrl = existing.fields["Image URL"];
-    if (existingUrl && isBlobUrl(existingUrl)) {
-      await deleteImage(existingUrl).catch(() => {});
-    }
+    // NOTE: We deliberately do NOT delete the existing Image URL's Blob here.
+    // The carousel flow (use-post-media → setMediaItems → saveImagesMutation)
+    // appends to the media array; what's currently in `Image URL` is usually
+    // still in use as carousel position 0. Eager-deleting it on every upload
+    // ate other carousel images and 404'd them at publish time. Orphan Blobs
+    // get garbage-collected separately by the cleanupCampaignPosts helper.
 
     // Upload to Vercel Blob
     const imageUrl = await uploadImage("posts", id, buffer, contentType);

--- a/src/app/api/posts/[id]/publish/route.ts
+++ b/src/app/api/posts/[id]/publish/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getRecord, updateRecord } from "@/lib/airtable/client";
 import { createBrandClient } from "@/lib/late-api/client";
-import { assembleCarouselPDF } from "@/lib/pdf-carousel";
+import { assembleCarouselPDF, prepareLinkedInPdfMetadata } from "@/lib/pdf-carousel";
 import { ensureAspectRatio } from "@/lib/image-crop";
 import { parseMediaItems } from "@/lib/media-items";
 import { SLIDE_PLATFORMS } from "@/lib/platform-constants";
@@ -26,6 +26,8 @@ interface PostFields {
 interface CampaignFields {
   Name: string;
   Brand: string[];
+  Description?: string;
+  "Editorial Direction"?: string;
 }
 
 interface BrandFields {
@@ -37,6 +39,7 @@ interface BrandFields {
   "Lnk.Bio Client ID Label"?: string;
   "Lnk.Bio Client Secret Label"?: string;
   "Outpaint Instead of Crop"?: boolean;
+  "Anthropic API Key Label"?: string;
 }
 
 const PLATFORM_MAP: Record<string, string> = {
@@ -151,24 +154,39 @@ export async function POST(
 
     // LinkedIn carousel: multiple images → assemble PDF document (with captions)
     let mediaItems: Array<{ type: "image" | "document"; url: string; filename?: string }>;
+    let linkedInDocumentTitle: string | undefined;
     const userPdfUrl = post.fields["Carousel PDF URL"] as string | undefined;
     if (platform === "linkedin" && userPdfUrl) {
       // User-supplied PDF override — skip auto-assembly entirely and ship
       // the attached PDF as a single document. Set via /api/posts/[id]/carousel-pdf.
-      const pdfDisplayName = `${(campaign.fields.Name || "Carousel").slice(0, 60)}.pdf`;
-      console.log(`[publish-now] LinkedIn user-PDF override: ${userPdfUrl}`);
+      const meta = await prepareLinkedInPdfMetadata({
+        campaignDescription: campaign.fields.Description,
+        editorialDirection: campaign.fields["Editorial Direction"],
+        postContent: post.fields.Content,
+        brand: { anthropicApiKeyLabel: brandRecord.fields["Anthropic API Key Label"] || null },
+      });
+      linkedInDocumentTitle = meta.documentTitle;
+      console.log(`[publish-now] LinkedIn user-PDF override: ${userPdfUrl} (filename="${meta.filename}", documentTitle="${meta.documentTitle}")`);
       mediaItems = [
-        { type: "document", url: userPdfUrl, filename: pdfDisplayName },
+        { type: "document", url: userPdfUrl, filename: meta.filename },
       ];
     } else if (platform === "linkedin" && imageUrls.length > 1) {
       console.log(`[publish-now] LinkedIn carousel: assembling ${postMediaItems.length} images into PDF`);
       const pdfBuffer = await assembleCarouselPDF(postMediaItems);
       console.log(`[publish-now] PDF assembled: ${(pdfBuffer.length / 1024).toFixed(0)}KB`);
 
+      const meta = await prepareLinkedInPdfMetadata({
+        campaignDescription: campaign.fields.Description,
+        editorialDirection: campaign.fields["Editorial Direction"],
+        postContent: post.fields.Content,
+        brand: { anthropicApiKeyLabel: brandRecord.fields["Anthropic API Key Label"] || null },
+      });
+      linkedInDocumentTitle = meta.documentTitle;
+
       // Upload PDF via Zernio presign
       const { data: presignData, error: presignError } = await client.media.getMediaPresignedUrl({
         body: {
-          filename: `${(campaign.fields.Name || "Carousel").slice(0, 60)}.pdf`,
+          filename: meta.filename,
           contentType: "application/pdf",
           size: pdfBuffer.length,
         },
@@ -197,9 +215,8 @@ export async function POST(
         );
       }
 
-      const pdfDisplayName = `${(campaign.fields.Name || "Carousel").slice(0, 60)}.pdf`;
-      console.log(`[publish-now] PDF uploaded to: ${presignData.publicUrl} (${pdfDisplayName})`);
-      mediaItems = [{ type: "document", url: presignData.publicUrl!, filename: pdfDisplayName }];
+      console.log(`[publish-now] PDF uploaded to: ${presignData.publicUrl} (filename="${meta.filename}", documentTitle="${meta.documentTitle}")`);
+      mediaItems = [{ type: "document", url: presignData.publicUrl!, filename: meta.filename }];
     } else if (imageUrls.length > 1 && !SLIDE_PLATFORMS.includes(platform)) {
       // Non-carousel platforms (Facebook, Pinterest, Twitter, etc.): Zernio
       // rejects multi-image posts. Match the UI's contract — use the first
@@ -228,6 +245,14 @@ export async function POST(
 
     if (post.fields["First Comment"]) {
       psd.firstComment = post.fields["First Comment"];
+    }
+
+    // LinkedIn document/PDF posts: populate documentTitle so the readable
+    // headline shows on the post tile instead of the filename. Field is on
+    // Zernio's wire format but not typed by SDK 0.1.7 — pass-through is safe
+    // since the SDK serializes the body as-is.
+    if (platform === "linkedin" && linkedInDocumentTitle) {
+      psd.documentTitle = linkedInDocumentTitle;
     }
 
     // Instagram-only: collaborators and user tags
@@ -261,6 +286,13 @@ export async function POST(
       scheduledFor: publishAt,
       timezone: brandRecord.fields.Timezone || "America/New_York",
     };
+
+    if (platform === "linkedin") {
+      console.log(
+        `[publish-now] LinkedIn createPost body:`,
+        JSON.stringify({ mediaItems: createBody.mediaItems, platforms: createBody.platforms }, null, 2)
+      );
+    }
 
     const { data: zernioPost, error: zernioError } = await client.posts.createPost({
       body: createBody as Parameters<typeof client.posts.createPost>[0]["body"],

--- a/src/app/api/tools/download-pdf/route.ts
+++ b/src/app/api/tools/download-pdf/route.ts
@@ -13,10 +13,10 @@ const PORT = 3025;
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   // slides comes as a comma-separated list, e.g. "A,2a,C"
-  const slides = (url.searchParams.get("slides") ?? "A,2a,C")
+  const slides = (url.searchParams.get("slides") ?? "A,i0")
     .split(",")
     .map((s) => s.trim())
-    .filter((s) => ["A", "2a", "2b", "C"].includes(s));
+    .filter((s) => s === "A" || s === "C" || /^i\d+$/.test(s));
   if (slides.length === 0) {
     return NextResponse.json({ error: "no slides" }, { status: 400 });
   }

--- a/src/app/api/tools/download-slide/route.ts
+++ b/src/app/api/tools/download-slide/route.ts
@@ -12,7 +12,9 @@ const PORT = 3025;
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const slide = url.searchParams.get("slide") ?? "A";
-  if (!["A", "2a", "2b", "C"].includes(slide)) {
+  // Inner slides are dynamic: any number of `iN` (i0, i1, …) is valid.
+  // Cover/CTA stay literal.
+  if (!(slide === "A" || slide === "C" || /^i\d+$/.test(slide))) {
     return NextResponse.json({ error: "Invalid slide" }, { status: 400 });
   }
 

--- a/src/app/dashboard/campaigns/new/page.tsx
+++ b/src/app/dashboard/campaigns/new/page.tsx
@@ -14,6 +14,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Badge } from "@/components/ui/badge";
 import { useBrand } from "@/lib/brand-context";
+import { pickBrandLogo } from "@/lib/brand-logo";
 import { cn } from "@/lib/utils";
 import {
   CAMPAIGN_TYPES,
@@ -330,17 +331,20 @@ export default function NewCampaignPage() {
             <div className="bg-zinc-900 px-5 py-3.5">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
-                  {currentBrand.logoUrl ? (
-                    <img
-                      src={currentBrand.logoUrl}
-                      alt={`${currentBrand.name} logo`}
-                      className="h-9 w-auto max-w-[120px] object-contain rounded"
-                    />
-                  ) : (
-                    <div className="h-9 w-9 rounded-lg bg-zinc-700 flex items-center justify-center text-zinc-300 text-base font-bold">
-                      {currentBrand.name.charAt(0)}
-                    </div>
-                  )}
+                  {(() => {
+                    const url = pickBrandLogo(currentBrand, { surface: "dark" });
+                    return url ? (
+                      <img
+                        src={url}
+                        alt={`${currentBrand.name} logo`}
+                        className="h-9 w-auto max-w-[120px] object-contain rounded"
+                      />
+                    ) : (
+                      <div className="h-9 w-9 rounded-lg bg-zinc-700 flex items-center justify-center text-zinc-300 text-base font-bold">
+                        {currentBrand.name.charAt(0)}
+                      </div>
+                    );
+                  })()}
                   <div>
                     <h3 className="text-base font-semibold text-white">
                       {currentBrand.name}
@@ -406,17 +410,20 @@ export default function NewCampaignPage() {
                       }}
                       className="flex items-center gap-3 w-full px-6 py-3 text-left hover:bg-muted/50 transition-colors"
                     >
-                      {brand.logoUrl ? (
-                        <img
-                          src={brand.logoUrl}
-                          alt=""
-                          className="h-7 w-7 rounded object-contain"
-                        />
-                      ) : (
-                        <span className="h-7 w-7 rounded bg-muted flex items-center justify-center text-xs font-bold">
-                          {brand.name.charAt(0)}
-                        </span>
-                      )}
+                      {(() => {
+                        const url = pickBrandLogo(brand, { surface: "light" });
+                        return url ? (
+                          <img
+                            src={url}
+                            alt=""
+                            className="h-7 w-7 rounded object-contain"
+                          />
+                        ) : (
+                          <span className="h-7 w-7 rounded bg-muted flex items-center justify-center text-xs font-bold">
+                            {brand.name.charAt(0)}
+                          </span>
+                        );
+                      })()}
                       <div>
                         <p className="text-sm font-medium">{brand.name}</p>
                         {brand.websiteUrl && (

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -26,6 +26,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
+import { pickBrandLogo } from "@/lib/brand-logo";
 import { Logo, ErrorBoundary } from "@/components/shared";
 import {
   LayoutDashboard,
@@ -254,15 +255,18 @@ export default function DashboardLayout({
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button variant="outline" size="sm" className="gap-2">
-                    {currentBrand?.logoUrl ? (
-                      <img
-                        src={currentBrand.logoUrl}
-                        alt=""
-                        className="h-4 w-4 rounded-sm object-contain"
-                      />
-                    ) : (
-                      <Palette className="h-4 w-4" />
-                    )}
+                    {(() => {
+                      const url = pickBrandLogo(currentBrand, { surface: "light" });
+                      return url ? (
+                        <img
+                          src={url}
+                          alt=""
+                          className="h-4 w-4 rounded-sm object-contain"
+                        />
+                      ) : (
+                        <Palette className="h-4 w-4" />
+                      );
+                    })()}
                     <span className="hidden sm:inline max-w-32 truncate text-sm">
                       {currentBrand?.name || "Select Brand"}
                     </span>
@@ -272,27 +276,30 @@ export default function DashboardLayout({
                 <DropdownMenuContent align="start" className="w-56">
                   <DropdownMenuLabel>Switch Brand</DropdownMenuLabel>
                   <DropdownMenuSeparator />
-                  {brands.map((brand) => (
-                    <DropdownMenuItem
-                      key={brand.id}
-                      onClick={() => switchBrand(brand.id)}
-                      className="gap-2"
-                    >
-                      {brand.logoUrl ? (
-                        <img
-                          src={brand.logoUrl}
-                          alt=""
-                          className="h-4 w-4 rounded-sm object-contain"
-                        />
-                      ) : (
-                        <Palette className="h-4 w-4 text-muted-foreground" />
-                      )}
-                      <span className="flex-1 truncate">{brand.name}</span>
-                      {brand.id === currentBrand?.id && (
-                        <Check className="h-4 w-4 text-primary" />
-                      )}
-                    </DropdownMenuItem>
-                  ))}
+                  {brands.map((brand) => {
+                    const url = pickBrandLogo(brand, { surface: "light" });
+                    return (
+                      <DropdownMenuItem
+                        key={brand.id}
+                        onClick={() => switchBrand(brand.id)}
+                        className="gap-2"
+                      >
+                        {url ? (
+                          <img
+                            src={url}
+                            alt=""
+                            className="h-4 w-4 rounded-sm object-contain"
+                          />
+                        ) : (
+                          <Palette className="h-4 w-4 text-muted-foreground" />
+                        )}
+                        <span className="flex-1 truncate">{brand.name}</span>
+                        {brand.id === currentBrand?.id && (
+                          <Check className="h-4 w-4 text-primary" />
+                        )}
+                      </DropdownMenuItem>
+                    );
+                  })}
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : null}

--- a/src/app/dashboard/settings/brands/page.tsx
+++ b/src/app/dashboard/settings/brands/page.tsx
@@ -20,6 +20,7 @@ import {
   SheetFooter,
 } from "@/components/ui/sheet";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { pickBrandLogo } from "@/lib/brand-logo";
 import { toast } from "sonner";
 import {
   ArrowLeft,
@@ -697,17 +698,20 @@ function BrandSettings({ brand }: { brand: Brand }) {
           <CardContent className="p-5">
             <div className="flex items-start justify-between gap-4">
               <div className="flex items-center gap-4 min-w-0">
-                {brand.logoUrl ? (
-                  <img
-                    src={brand.logoUrl}
-                    alt={`${brand.name} logo`}
-                    className="h-12 w-auto max-w-[160px] object-contain rounded shrink-0"
-                  />
-                ) : (
-                  <div className="h-12 w-12 rounded-lg bg-muted flex items-center justify-center text-muted-foreground text-lg font-bold shrink-0">
-                    {brand.name.charAt(0)}
-                  </div>
-                )}
+                {(() => {
+                  const url = pickBrandLogo(brand, { surface: "light" });
+                  return url ? (
+                    <img
+                      src={url}
+                      alt={`${brand.name} logo`}
+                      className="h-12 w-auto max-w-[160px] object-contain rounded shrink-0"
+                    />
+                  ) : (
+                    <div className="h-12 w-12 rounded-lg bg-muted flex items-center justify-center text-muted-foreground text-lg font-bold shrink-0">
+                      {brand.name.charAt(0)}
+                    </div>
+                  );
+                })()}
                 <div className="min-w-0">
                   {editingDetails ? (
                     <Input

--- a/src/app/dashboard/settings/brands/page.tsx
+++ b/src/app/dashboard/settings/brands/page.tsx
@@ -631,6 +631,7 @@ function BrandSettings({ brand }: { brand: Brand }) {
     name: brand.name,
     websiteUrl: brand.websiteUrl,
     newsletterUrl: brand.newsletterUrl,
+    subscribeUrl: brand.subscribeUrl ?? "",
   });
 
   // Voice guidelines draft
@@ -666,6 +667,7 @@ function BrandSettings({ brand }: { brand: Brand }) {
       name: brand.name,
       websiteUrl: brand.websiteUrl,
       newsletterUrl: brand.newsletterUrl,
+      subscribeUrl: brand.subscribeUrl ?? "",
     });
     setEditingDetails(false);
   };
@@ -786,6 +788,17 @@ function BrandSettings({ brand }: { brand: Brand }) {
                     className="text-sm h-8"
                   />
                 </div>
+                <div>
+                  <Label className="text-xs text-muted-foreground flex items-center gap-1 mb-1">
+                    <Globe className="h-3 w-3" /> Subscribe URL
+                  </Label>
+                  <Input
+                    value={detailsDraft.subscribeUrl}
+                    onChange={(e) => setDetailsDraft({ ...detailsDraft, subscribeUrl: e.target.value })}
+                    placeholder="theintersect.art (no protocol — used as visible CTA on cover-generator subscribe cells)"
+                    className="text-sm h-8"
+                  />
+                </div>
               </div>
             ) : (
               <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-3 pt-3 border-t text-xs text-muted-foreground">
@@ -839,9 +852,6 @@ function BrandSettings({ brand }: { brand: Brand }) {
           </CardContent>
         </Card>
 
-        {/* ── Brand Logos ─────────────────────────────────────────── */}
-        <LogoManager brand={brand} />
-
         {/* ── Cover Generator (Intersect only — dev tool) ─────────── */}
         {brand?.name === "The Intersect" && (
           <Card>
@@ -861,6 +871,9 @@ function BrandSettings({ brand }: { brand: Brand }) {
             </CardContent>
           </Card>
         )}
+
+        {/* ── Brand Logos ─────────────────────────────────────────── */}
+        <LogoManager brand={brand} />
 
         {/* ── Voice Guidelines ────────────────────────────────────── */}
         <Card>

--- a/src/app/dashboard/tools/cover-generator/page.tsx
+++ b/src/app/dashboard/tools/cover-generator/page.tsx
@@ -73,6 +73,93 @@ const SIZE_LI = { w: 1080, h: 1080 }; // LinkedIn document carousel 1:1
 const SCALE = 0.42;
 const DISPLAY_W = 1080 * SCALE; // width is always 1080, only height varies
 
+// ── Inner-slide model ─────────────────────────────────────────────────
+//
+// Both LI 1:1 and IG 4:5 carousels pack 2 stories per inner slide. With N
+// picked stories you get ceil(N/2) inner slides; if N is odd the final slot
+// pairs the orphaned story with a "subscribe" cell built from the issue's
+// hero image (LI: visible URL footer; IG: "LINK IN BIO" footer).
+const STORIES_PER_INNER = 2;
+const MAX_STORY_PICKS = 12;
+const FALLBACK_SUBSCRIBE_URL = "theintersect.art";
+
+type ImagePos = { x: number; y: number; zoom: number };
+const DEFAULT_IMAGE_POS: ImagePos = { x: 50, y: 50, zoom: 1 };
+
+type StoryPick = {
+  title: string;
+  imageUrl: string | null;
+  imagePos?: ImagePos; // per-image drag-reposition; undefined means use default
+};
+
+// Per-inner-slide editable state — what used to live as discrete numeralA/B,
+// bg2a/b, etc. variables. Now an array entry per inner slide.
+type InnerSlideState = {
+  numeral: { fontSize: number; dx: number; dy: number };
+  bgColor: string | null; // hex override; null = cream default
+  bgLightness: number; // -50..50
+  taglineFs: number; // px
+  logoLeft: boolean;
+};
+const DEFAULT_INNER: InnerSlideState = {
+  numeral: { fontSize: 245, dx: -29, dy: -48 },
+  bgColor: null,
+  bgLightness: 0,
+  taglineFs: 50,
+  logoLeft: true,
+};
+
+// Discriminated cell type for the 2-cell inner-slide grid. Subscribe cell is
+// the orphan-filler when picks.length is odd (LI) or as a graceful gap-filler
+// for IG when picks aren't a multiple of STORIES_PER_INNER.
+type Cell =
+  | { kind: "story"; story: StoryPick }
+  | { kind: "subscribe"; heroSrc: string; subscribeUrl: string; format: "li" | "ig" };
+
+// Compute the carousel slide list for a given pick count + format.
+//   LI: [A, i0, i1, …, iN]  (no closing C; CTA lives in post body)
+//   IG: [A, i0, i1, …, iN, C]
+// Inner-slide count = max(1, ceil(picks/STORIES_PER_INNER)). Always at least
+// one inner slide so the carousel previews even with no picks.
+function computeSlideList(
+  picksLength: number,
+  format: "li" | "ig",
+): string[] {
+  const innerCount = Math.max(
+    1,
+    Math.ceil(picksLength / STORIES_PER_INNER),
+  );
+  const inners = Array.from({ length: innerCount }, (_, i) => `i${i}`);
+  return format === "li" ? ["A", ...inners] : ["A", ...inners, "C"];
+}
+
+// Build the 2-cell array for a given inner-slide index. If the slot would
+// otherwise be empty (orphaned story or no picks), fill with a subscribe cell.
+function computeCells(
+  picks: StoryPick[],
+  innerIdx: number,
+  heroSrc: string,
+  subscribeUrl: string,
+  format: "li" | "ig",
+): Cell[] {
+  const start = innerIdx * STORIES_PER_INNER;
+  const slot1 = picks[start];
+  const slot2 = picks[start + 1];
+  const cells: Cell[] = [];
+  if (slot1) cells.push({ kind: "story", story: slot1 });
+  if (slot2) cells.push({ kind: "story", story: slot2 });
+  // Pad to 2 cells. Subscribe cell fills any vacancy.
+  while (cells.length < STORIES_PER_INNER) {
+    cells.push({
+      kind: "subscribe",
+      heroSrc,
+      subscribeUrl,
+      format,
+    });
+  }
+  return cells;
+}
+
 const SizeContext = createContext<{ w: number; h: number }>(SIZE_IG);
 const useSize = () => useContext(SizeContext);
 
@@ -211,8 +298,8 @@ function useBottomBandSample(src: string) {
   return color;
 }
 
-type ImagePos = { x: number; y: number; zoom: number };
-
+// ImagePos is declared near the top of the file alongside the inner-slide
+// model. Kept here only for the clamp helper that follows.
 const clamp = (n: number, min = 0, max = 100) =>
   Math.max(min, Math.min(max, n));
 
@@ -1283,24 +1370,257 @@ function TemplateA({
   );
 }
 
-type Story = { title: string; imageUrl: string | null };
+// Inner-slide cell renderer. Renders either a story image card with a
+// drag-to-reposition affordance + title overlay, or a "subscribe" card built
+// from the issue's hero image with a format-appropriate CTA footer (LI shows
+// the subscribe URL; IG shows "LINK IN BIO →").
+function CellRenderer({
+  cell,
+  cellIdx,
+  onImagePosChange,
+}: {
+  cell: Cell;
+  cellIdx: number;
+  onImagePosChange?: (cellIdx: number, pos: ImagePos) => void;
+}) {
+  if (cell.kind === "subscribe") {
+    return (
+      <div
+        style={{
+          position: "relative",
+          overflow: "hidden",
+          background: "#222",
+        }}
+      >
+        <img
+          src={cell.heroSrc}
+          alt=""
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            opacity: 0.55,
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            background:
+              "linear-gradient(to bottom, rgba(0,0,0,0.35) 0%, rgba(0,0,0,0.85) 100%)",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "center",
+            padding: 24,
+            color: "#fff",
+            textAlign: "center",
+            fontFamily: '"Noto Sans", system-ui, sans-serif',
+            gap: 10,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 14,
+              letterSpacing: 4,
+              opacity: 0.7,
+            }}
+          >
+            ENJOYED THIS ISSUE?
+          </div>
+          <div
+            style={{
+              fontFamily: '"Noto Serif", Georgia, serif',
+              fontStyle: "italic",
+              fontSize: 32,
+              lineHeight: 1.15,
+              fontWeight: 400,
+            }}
+          >
+            Subscribe to The Intersect
+          </div>
+          <div
+            style={{
+              marginTop: 6,
+              fontSize: 14,
+              letterSpacing: 3,
+              fontWeight: 700,
+            }}
+          >
+            {cell.format === "li"
+              ? cell.subscribeUrl.toUpperCase()
+              : "LINK IN BIO →"}
+          </div>
+        </div>
+      </div>
+    );
+  }
+  // story cell — drag-to-reposition image + title overlay
+  const story = cell.story;
+  const pos = story.imagePos ?? DEFAULT_IMAGE_POS;
+  const isDraggable = !!onImagePosChange;
+  return (
+    <div
+      style={{
+        position: "relative",
+        overflow: "hidden",
+        background: "#222",
+        // Enforce aspect ratio so portrait-ish photos don't get squished into
+        // wide banners by flex:1 layout. Matches the original cell shape.
+        aspectRatio: "16 / 11",
+      }}
+    >
+      {story.imageUrl ? (
+        isDraggable ? (
+          <CellDraggableImage
+            src={story.imageUrl}
+            pos={pos}
+            onChange={(p) => onImagePosChange!(cellIdx, p)}
+          />
+        ) : (
+          <img
+            src={story.imageUrl}
+            alt=""
+            style={{
+              position: "absolute",
+              inset: 0,
+              width: "100%",
+              height: "100%",
+              objectFit: "cover",
+              objectPosition: `${pos.x}% ${pos.y}%`,
+              transform: `scale(${pos.zoom})`,
+              transformOrigin: `${pos.x}% ${pos.y}%`,
+              opacity: 0.95,
+            }}
+          />
+        )
+      ) : (
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            background: "linear-gradient(135deg,#1a1a1a,#2e2e2e)",
+          }}
+        />
+      )}
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          bottom: 0,
+          padding: "60px 18px 14px",
+          background:
+            "linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0) 100%)",
+          color: "#fff",
+          fontFamily: '"Noto Sans", system-ui, sans-serif',
+          fontWeight: 400,
+          fontSize: 19,
+          lineHeight: 1.3,
+          letterSpacing: 0.1,
+          pointerEvents: "none",
+        }}
+      >
+        {story.title}
+      </div>
+    </div>
+  );
+}
 
-function TemplateB_Square({
+// Cell-scoped variant of DraggableImage that fills its parent (no SizeContext
+// dependency — the parent grid cell is the bounds, not the slide canvas).
+function CellDraggableImage({
+  src,
+  pos,
+  onChange,
+}: {
+  src: string;
+  pos: ImagePos;
+  onChange: (next: ImagePos) => void;
+}) {
+  const [drag, setDrag] = useState<{
+    x: number;
+    y: number;
+    posX: number;
+    posY: number;
+  } | null>(null);
+  return (
+    <div
+      onPointerDown={(e) => {
+        (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
+        setDrag({
+          x: e.clientX,
+          y: e.clientY,
+          posX: pos.x,
+          posY: pos.y,
+        });
+      }}
+      onPointerMove={(e) => {
+        if (!drag) return;
+        const rect = e.currentTarget.getBoundingClientRect();
+        const dx = ((e.clientX - drag.x) / rect.width) * 100;
+        const dy = ((e.clientY - drag.y) / rect.height) * 100;
+        onChange({
+          ...pos,
+          x: clamp(drag.posX - dx),
+          y: clamp(drag.posY - dy),
+        });
+      }}
+      onPointerUp={() => setDrag(null)}
+      style={{
+        position: "absolute",
+        inset: 0,
+        cursor: drag ? "grabbing" : "grab",
+        touchAction: "none",
+      }}
+    >
+      <img
+        src={src}
+        alt=""
+        draggable={false}
+        style={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+          objectFit: "cover",
+          objectPosition: `${pos.x}% ${pos.y}%`,
+          transform: `scale(${pos.zoom})`,
+          transformOrigin: `${pos.x}% ${pos.y}%`,
+          pointerEvents: "none",
+          userSelect: "none",
+        }}
+      />
+    </div>
+  );
+}
+
+function TemplateB_Cells({
   numeralPos,
   onNumeralChange,
-  stories,
+  cells,
   tagline,
   bgColor = PALETTE.cream,
-  taglineFontSize = 50,
+  taglineFontSize,
   cta = "LINK IN BIO →",
   logoLeft = true,
   issueNumber,
   brandLong,
   date,
+  format,
+  onCellImagePosChange,
 }: {
   numeralPos: NumeralPos;
   onNumeralChange: (next: NumeralPos) => void;
-  stories: Story[];
+  cells: Cell[]; // exactly 2; story or subscribe per slot
   tagline: string;
   bgColor?: string;
   taglineFontSize?: number;
@@ -1309,10 +1629,19 @@ function TemplateB_Square({
   issueNumber: number;
   brandLong: string;
   date: string;
+  format: "li" | "ig";
+  /** Live canvas only: persists drag position for story cells back to picker
+   *  state. Render mode passes undefined → cells render with their stored
+   *  position but aren't draggable. */
+  onCellImagePosChange?: (cellIdx: number, pos: ImagePos) => void;
 }) {
   const size = useSize();
-  const inset = 60;
-  const ROW_H = 240;
+  // Format-aware layout: IG 4:5 stacks cells vertically with wider L/R inset
+  // (turns each cell into a tall near-square frame instead of a 16:11 sliver);
+  // LI 1:1 keeps cells side-by-side with the original tighter inset.
+  const isLI = format === "li";
+  const inset = isLI ? 60 : 120;
+  const ROW_H = isLI ? 240 : 180;
   const bgIsLight = hexLuminance(bgColor) > 0.55;
   const fg = bgIsLight ? PALETTE.ink : "#f5f4ee";
   const fgSoft = bgIsLight ? PALETTE.inkSoft : "rgba(245,244,238,0.7)";
@@ -1403,64 +1732,22 @@ function TemplateB_Square({
         style={{
           flex: 1,
           display: "grid",
-          gridTemplateColumns: "1fr 1fr",
-          gridTemplateRows:
-            stories.length <= 2 ? "auto" : "auto auto",
+          // LI: cells side-by-side. IG: stacked vertically (one above the
+          // other) so each cell becomes a tall near-square frame.
+          gridTemplateColumns: isLI ? "1fr 1fr" : "1fr",
+          gridTemplateRows: isLI ? "1fr" : "1fr 1fr",
           gap: 12,
           padding: `0 ${inset}px`,
           alignContent: "center",
         }}
       >
-        {stories.slice(0, 4).map((s, i) => (
-          <div
+        {cells.slice(0, 2).map((cell, i) => (
+          <CellRenderer
             key={i}
-            style={{
-              position: "relative",
-              overflow: "hidden",
-              background: "#222",
-              aspectRatio: "16 / 11",
-            }}
-          >
-            {s.imageUrl ? (
-              <img
-                src={s.imageUrl}
-                alt=""
-                style={{
-                  width: "100%",
-                  height: "100%",
-                  objectFit: "cover",
-                  opacity: 0.95,
-                }}
-              />
-            ) : (
-              <div
-                style={{
-                  width: "100%",
-                  height: "100%",
-                  background: "linear-gradient(135deg,#1a1a1a,#2e2e2e)",
-                }}
-              />
-            )}
-            <div
-              style={{
-                position: "absolute",
-                left: 0,
-                right: 0,
-                bottom: 0,
-                padding: "60px 18px 14px",
-                background:
-                  "linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0) 100%)",
-                color: "#fff",
-                fontFamily: '"Noto Sans", system-ui, sans-serif',
-                fontWeight: 400,
-                fontSize: 19,
-                lineHeight: 1.3,
-                letterSpacing: 0.1,
-              }}
-            >
-              {s.title}
-            </div>
-          </div>
+            cell={cell}
+            cellIdx={i}
+            onImagePosChange={onCellImagePosChange}
+          />
         ))}
       </div>
 
@@ -1504,225 +1791,6 @@ function TemplateB_Square({
   );
 }
 
-function TemplateB_Rect({
-  numeralPos,
-  onNumeralChange,
-  stories,
-  tagline,
-  bgColor = PALETTE.cream,
-  taglineFontSize = 44,
-  cta = "LINK IN BIO →",
-  logoLeft = true,
-  issueNumber,
-  brandLong,
-  date,
-}: {
-  numeralPos: NumeralPos;
-  onNumeralChange: (next: NumeralPos) => void;
-  stories: Story[];
-  tagline: string;
-  bgColor?: string;
-  taglineFontSize?: number;
-  cta?: string;
-  logoLeft?: boolean;
-  issueNumber: number;
-  brandLong: string;
-  date: string;
-}) {
-  const size = useSize();
-  const inset = 60;
-  const ROW_H = 200;
-  const bgIsLight = hexLuminance(bgColor) > 0.55;
-  const bg = bgColor;
-  const fg = bgIsLight ? PALETTE.ink : "#f5f4ee";
-  const fgSoft = bgIsLight ? PALETTE.inkSoft : "rgba(245,244,238,0.7)";
-  const borderTop = bgIsLight
-    ? "rgba(0,0,0,0.15)"
-    : "rgba(255,255,255,0.18)";
-
-  return (
-    <div
-      style={{
-        width: size.w,
-        height: size.h,
-        background: bg,
-        color: fg,
-        display: "flex",
-        flexDirection: "column",
-        fontFamily: '"Noto Sans", system-ui, sans-serif',
-        position: "relative",
-      }}
-    >
-      <div
-        style={{
-          position: "absolute",
-          top: inset,
-          left: inset,
-          right: inset,
-          height: ROW_H,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-        }}
-      >
-        {logoLeft ? (
-          <>
-            <img
-              src={BRAND_LOGO_RECT}
-              alt={brandLong}
-              style={{
-                height: ROW_H,
-                width: "auto",
-                objectFit: "contain",
-                opacity: 0.5,
-                filter: bgIsLight
-                  ? "brightness(0)"
-                  : "brightness(0) invert(1)",
-              }}
-            />
-            <DraggableNumeral
-              value={issueNumber}
-              rowH={ROW_H}
-              pos={numeralPos}
-              onChange={onNumeralChange}
-              letterSpacing={-8}
-              color={fg}
-              opacity={0.5}
-            />
-          </>
-        ) : (
-          <>
-            <DraggableNumeral
-              value={issueNumber}
-              rowH={ROW_H}
-              pos={numeralPos}
-              onChange={onNumeralChange}
-              letterSpacing={-8}
-              color={fg}
-              opacity={0.5}
-            />
-            <img
-              src={BRAND_LOGO_RECT}
-              alt={brandLong}
-              style={{
-                height: ROW_H,
-                width: "auto",
-                objectFit: "contain",
-                opacity: 0.5,
-                filter: bgIsLight
-                  ? "brightness(0)"
-                  : "brightness(0) invert(1)",
-              }}
-            />
-          </>
-        )}
-      </div>
-
-      <div style={{ height: inset + ROW_H + inset, flexShrink: 0 }} />
-
-      <div
-        style={{
-          flex: 1,
-          display: "grid",
-          gridTemplateColumns: "1fr 1fr",
-          gridTemplateRows:
-            stories.length <= 2 ? "auto" : "auto auto",
-          gap: 12,
-          padding: `0 ${inset}px`,
-          alignContent: "center",
-        }}
-      >
-        {stories.slice(0, 4).map((s, i) => (
-          <div
-            key={i}
-            style={{
-              position: "relative",
-              overflow: "hidden",
-              background: "#222",
-              aspectRatio: "16 / 11",
-            }}
-          >
-            {s.imageUrl ? (
-              <img
-                src={s.imageUrl}
-                alt=""
-                style={{
-                  width: "100%",
-                  height: "100%",
-                  objectFit: "cover",
-                  opacity: 0.95,
-                }}
-              />
-            ) : (
-              <div
-                style={{
-                  width: "100%",
-                  height: "100%",
-                  background: "linear-gradient(135deg,#1a1a1a,#2e2e2e)",
-                }}
-              />
-            )}
-            <div
-              style={{
-                position: "absolute",
-                left: 0,
-                right: 0,
-                bottom: 0,
-                padding: "60px 18px 14px",
-                background:
-                  "linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0) 100%)",
-                color: "#fff",
-                fontFamily: '"Noto Sans", system-ui, sans-serif',
-                fontWeight: 400,
-                fontSize: 19,
-                lineHeight: 1.3,
-                letterSpacing: 0.1,
-              }}
-            >
-              {s.title}
-            </div>
-          </div>
-        ))}
-      </div>
-
-      <div
-        style={{
-          padding: `${inset}px ${inset}px ${inset}px`,
-          display: "flex",
-          flexDirection: "column",
-          gap: 28,
-        }}
-      >
-        <div
-          style={{
-            fontFamily: '"Noto Serif", Georgia, serif',
-            fontStyle: "italic",
-            fontSize: taglineFontSize,
-            color: fg,
-            lineHeight: 1.2,
-            letterSpacing: -0.5,
-          }}
-        >
-          {tagline}
-        </div>
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "baseline",
-            paddingTop: 22,
-            borderTop: `1px solid ${borderTop}`,
-            fontSize: 22,
-            letterSpacing: 3,
-          }}
-        >
-          <div style={{ color: fgSoft }}>{date}</div>
-          <div style={{ color: fg, fontWeight: 700 }}>{cta}</div>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 function TemplateC({
   heroSrc,
@@ -1850,12 +1918,9 @@ type UpscaleStatus = {
 // useSearchParams() doesn't fail Next.js's CSR-bailout check at build time.
 function OverviewCoversDevPage() {
   const searchParams = useSearchParams();
-  const renderSlide = searchParams.get("render") as
-    | "A"
-    | "2a"
-    | "2b"
-    | "C"
-    | null;
+  // renderSlide accepts "A", "C", or "iN" (any inner-slide index). Validated
+  // at use sites — anything else returns null and the page renders normally.
+  const renderSlide = searchParams.get("render");
   // For render mode, prefer query-param state; defaults match the baked-in.
   const qpNum = (k: string, d: number) => {
     const v = searchParams.get(k);
@@ -1916,48 +1981,6 @@ function OverviewCoversDevPage() {
     "overview-cover-bandBlurA",
     qpNum("bb", 0),
   );
-  const [bg2a, setBg2a] = useLocalStorage<string | null>(
-    "overview-cover-bg2a",
-    qpStr("bg2a"),
-  );
-  const [bgL2a, setBgL2a] = useLocalStorage<number>(
-    "overview-cover-bgL2a",
-    qpNum("bgL2a", 0),
-  );
-  const [bg2b, setBg2b] = useLocalStorage<string | null>(
-    "overview-cover-bg2b",
-    qpStr("bg2b"),
-  );
-  const [bgL2b, setBgL2b] = useLocalStorage<number>(
-    "overview-cover-bgL2b",
-    qpNum("bgL2b", 0),
-  );
-  const [tagFs2a, setTagFs2a] = useLocalStorage<number>(
-    "overview-cover-tagFs2a",
-    qpNum("t2afs", 50),
-  );
-  const [tagFs2b, setTagFs2b] = useLocalStorage<number>(
-    "overview-cover-tagFs2b",
-    qpNum("t2bfs", 44),
-  );
-  const bgFinal2a = adjustLightness(bg2a ?? PALETTE.cream, bgL2a);
-  const bgFinal2b = adjustLightness(bg2b ?? PALETTE.cream, bgL2b);
-  const [numeralA, setNumeralA] = useLocalStorage<NumeralPos>(
-    "overview-cover-numeralA",
-    {
-      fontSize: qpNum("nafs", 265),
-      dx: qpNum("nadx", -29),
-      dy: qpNum("nady", -48),
-    },
-  );
-  const [numeralB, setNumeralB] = useLocalStorage<NumeralPos>(
-    "overview-cover-numeralB",
-    {
-      fontSize: qpNum("nbfs", 225),
-      dx: qpNum("nbdx", -11),
-      dy: qpNum("nbdy", -41),
-    },
-  );
   const [slide1NumeralLeft, setSlide1NumeralLeft] = useLocalStorage<boolean>(
     "overview-cover-slide1NumeralLeft",
     qpStr("s1l") === "1",
@@ -1973,14 +1996,78 @@ function OverviewCoversDevPage() {
       "overview-cover-slide1NumeralOpacity",
       qpNum("s1no", 18),
     );
-  const [slide2aLogoLeft, setSlide2aLogoLeft] = useLocalStorage<boolean>(
-    "overview-cover-slide2aLogoLeft",
-    qpStr("s2al") !== null ? qpStr("s2al") === "1" : true,
+  // Inner-slide state — array entry per inner slide. Render mode hydrates
+  // from the `is` URL param when present (Puppeteer headless has no
+  // localStorage). On first hydration of an empty array, a one-time
+  // migration shim seeds index 0 + 1 from the legacy 2a/2b state so the
+  // user's prior tweaks survive.
+  const initialInnerSlides: InnerSlideState[] = (() => {
+    const raw = qpStr("is");
+    if (!raw) return [];
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed as InnerSlideState[];
+    } catch {
+      // ignore — fall through
+    }
+    return [];
+  })();
+  const [innerSlides, setInnerSlides] = useLocalStorage<InnerSlideState[]>(
+    "overview-cover-innerSlides",
+    initialInnerSlides,
   );
-  const [slide2bLogoLeft, setSlide2bLogoLeft] = useLocalStorage<boolean>(
-    "overview-cover-slide2bLogoLeft",
-    qpStr("s2bl") !== null ? qpStr("s2bl") === "1" : true,
-  );
+
+  // One-time migration: if innerSlides is empty AND any of the legacy 2a/2b
+  // localStorage keys exist, seed the first two entries from them so the
+  // user's prior per-slide tweaks survive the refactor. Guarded by a flag
+  // key so it runs at most once per browser. Reads localStorage directly
+  // (not the React state) because the legacy state vars are about to be
+  // removed in step 6.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.localStorage.getItem("overview-cover-migrated-v2") === "1") return;
+    if (innerSlides.length > 0) {
+      window.localStorage.setItem("overview-cover-migrated-v2", "1");
+      return;
+    }
+    const readJson = <T,>(k: string, fallback: T): T => {
+      try {
+        const raw = window.localStorage.getItem(k);
+        return raw ? (JSON.parse(raw) as T) : fallback;
+      } catch {
+        return fallback;
+      }
+    };
+    const seed = (a: "A" | "B"): InnerSlideState => ({
+      numeral: readJson(`overview-cover-numeral${a}`, DEFAULT_INNER.numeral),
+      bgColor: readJson<string | null>(
+        `overview-cover-bg2${a.toLowerCase()}`,
+        null,
+      ),
+      bgLightness: readJson<number>(
+        `overview-cover-bgL2${a.toLowerCase()}`,
+        0,
+      ),
+      taglineFs: readJson<number>(
+        `overview-cover-tagFs2${a.toLowerCase()}`,
+        a === "A" ? 50 : 44,
+      ),
+      logoLeft: readJson<boolean>(
+        `overview-cover-slide2${a.toLowerCase()}LogoLeft`,
+        true,
+      ),
+    });
+    setInnerSlides([seed("A"), seed("B")]);
+    window.localStorage.setItem("overview-cover-migrated-v2", "1");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const updateInner = (idx: number, patch: Partial<InnerSlideState>) => {
+    setInnerSlides(
+      innerSlides.map((s, j) => (j === idx ? { ...s, ...patch } : s)),
+    );
+  };
+
   const [upscale, setUpscale] = useState<UpscaleStatus>({ state: "idle" });
   const [taglineFsA, setTaglineFsA] = useLocalStorage<number>(
     "overview-cover-taglineFsA",
@@ -2028,9 +2115,27 @@ function OverviewCoversDevPage() {
     }
     return [];
   })();
-  const [storyPicks, setStoryPicks] = useLocalStorage<
-    { title: string; imageUrl: string | null }[]
-  >("overview-cover-storyPicks", initialStoryPicks);
+  const [storyPicks, setStoryPicks] = useLocalStorage<StoryPick[]>(
+    "overview-cover-storyPicks",
+    initialStoryPicks,
+  );
+
+  // Auto-grow innerSlides when storyPicks count requires more inner slides.
+  // Never shrinks (preserves user-tuned slots when picks decrease).
+  const requiredInnerCount = Math.max(
+    1,
+    Math.ceil(storyPicks.length / STORIES_PER_INNER),
+  );
+  useEffect(() => {
+    if (innerSlides.length < requiredInnerCount) {
+      const next = [...innerSlides];
+      while (next.length < requiredInnerCount) {
+        next.push({ ...DEFAULT_INNER });
+      }
+      setInnerSlides(next);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [requiredInnerCount]);
 
   const sampleA = useBottomBandSample(heroSrc);
   const sampledHex = sampleA ? rgbToHex(sampleA.rgb) : null;
@@ -2045,9 +2150,7 @@ function OverviewCoversDevPage() {
     setBandBlurA(0);
   };
 
-  const buildDownloadHref = (
-    slide: "A" | "2a" | "2b" | "C",
-  ): string => {
+  const buildDownloadHref = (slide: string): string => {
     const sp = new URLSearchParams({ slide });
     sp.set("fmt", format);
     // Issue data flows to render mode through these params so the rendered PNG
@@ -2076,31 +2179,19 @@ function OverviewCoversDevPage() {
       sp.set("cy", String(posC.y));
       sp.set("cz", String(posC.zoom));
     }
-    if (slide === "2a" || slide === "2b") {
-      // Story picks need to flow into render mode via the URL — Puppeteer
-      // launches with empty localStorage, so without this the download falls
-      // back to an empty grid.
+    if (/^i\d+$/.test(slide)) {
+      // Story picks (incl. per-image drag positions) and inner-slide state
+      // arrays both flow into render mode via JSON URL params — Puppeteer
+      // launches with empty localStorage so without these the download
+      // would lose all of it.
       if (storyPicks.length > 0) {
         sp.set("sp", JSON.stringify(storyPicks));
       }
-    }
-    if (slide === "2a") {
-      sp.set("nafs", String(numeralA.fontSize));
-      sp.set("nadx", String(numeralA.dx));
-      sp.set("nady", String(numeralA.dy));
-      if (bg2a) sp.set("bg2a", bg2a);
-      sp.set("bgL2a", String(bgL2a));
-      sp.set("t2afs", String(tagFs2a));
-      sp.set("s2al", slide2aLogoLeft ? "1" : "0");
-    }
-    if (slide === "2b") {
-      sp.set("nbfs", String(numeralB.fontSize));
-      sp.set("nbdx", String(numeralB.dx));
-      sp.set("nbdy", String(numeralB.dy));
-      if (bg2b) sp.set("bg2b", bg2b);
-      sp.set("bgL2b", String(bgL2b));
-      sp.set("t2bfs", String(tagFs2b));
-      sp.set("s2bl", slide2bLogoLeft ? "1" : "0");
+      // Subscribe URL needed for orphan-cell rendering when picks count is odd.
+      sp.set("subs", subscribeUrl);
+      // Hero URL needed for the subscribe-cell background.
+      sp.set("hero", heroSrc);
+      sp.set("is", JSON.stringify(innerSlides));
     }
     return `/api/tools/download-slide?${sp.toString()}`;
   };
@@ -2146,7 +2237,40 @@ function OverviewCoversDevPage() {
   // picked any yet, the templates render placeholder card backgrounds — far
   // better than silently falling back to hardcoded URLs from a different
   // issue, which is what the prior STORY_IMAGES + STORY_TITLES constants did.
-  const effectiveStories: Story[] = storyPicks;
+  const effectiveStories: StoryPick[] = storyPicks;
+  // Subscribe URL for the orphan-cell. Render mode reads `?subs=...` from the
+  // URL (Puppeteer can't refetch). Live page fetches the Intersect brand
+  // record once on mount and uses its `Subscribe URL` field. Falls back to a
+  // bare-domain constant only if both routes fail.
+  const [brandSubscribeUrl, setBrandSubscribeUrl] = useState<string | null>(
+    qpStr("subs"),
+  );
+  useEffect(() => {
+    if (brandSubscribeUrl) return; // already set from URL
+    let cancelled = false;
+    fetch("/api/brands?status=Active")
+      .then((r) => r.json())
+      .then((d) => {
+        if (cancelled) return;
+        const intersect = (d.brands as { name: string; subscribeUrl?: string }[])
+          ?.find((b) => /intersect/i.test(b.name));
+        if (intersect?.subscribeUrl) setBrandSubscribeUrl(intersect.subscribeUrl);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const subscribeUrl = brandSubscribeUrl || FALLBACK_SUBSCRIBE_URL;
+  // imagePos drag handler — writes back to storyPicks at the matching cell.
+  // The cellIdx is local to its inner slide; we resolve to the global pick
+  // index via the inner-slide offset at the call site.
+  const updateStoryImagePos = (storyIdx: number, pos: ImagePos) => {
+    setStoryPicks(
+      storyPicks.map((s, j) => (j === storyIdx ? { ...s, imagePos: pos } : s)),
+    );
+  };
 
   // Curator fetch state
   const [curatorState, setCuratorState] = useState<{
@@ -2212,7 +2336,7 @@ function OverviewCoversDevPage() {
     const idx = storyPicks.findIndex((s) => s.title === entry.title);
     if (idx >= 0) {
       setStoryPicks(storyPicks.filter((_, i) => i !== idx));
-    } else if (storyPicks.length < 4) {
+    } else if (storyPicks.length < MAX_STORY_PICKS) {
       setStoryPicks([...storyPicks, entry]);
     }
   };
@@ -2240,57 +2364,37 @@ function OverviewCoversDevPage() {
           date={issueData.date}
         />
       );
-    else if (renderSlide === "2a")
+    else if (renderSlide.match(/^i(\d+)$/)) {
+      const innerIdx = Number(renderSlide.slice(1));
+      const slideState = innerSlides[innerIdx] ?? DEFAULT_INNER;
+      const cells = computeCells(
+        effectiveStories,
+        innerIdx,
+        heroSrc,
+        subscribeUrl,
+        format,
+      );
+      const bg = adjustLightness(
+        slideState.bgColor ?? PALETTE.cream,
+        slideState.bgLightness,
+      );
       node = (
-        <TemplateB_Square
-          numeralPos={numeralA}
-          onNumeralChange={setNumeralA}
-          stories={
-            format === "li"
-              ? effectiveStories.slice(0, 2)
-              : effectiveStories.slice(0, 4)
-          }
+        <TemplateB_Cells
+          numeralPos={slideState.numeral}
+          onNumeralChange={(p) => updateInner(innerIdx, { numeral: p })}
+          cells={cells}
           tagline={issueData.tagline}
-          bgColor={bgFinal2a}
-          taglineFontSize={tagFs2a}
+          bgColor={bg}
+          taglineFontSize={slideState.taglineFs}
           cta={slide2Cta}
-          logoLeft={slide2aLogoLeft}
+          logoLeft={slideState.logoLeft}
           issueNumber={issueData.number}
           brandLong={issueData.brandLong}
           date={issueData.date}
+          format={format}
         />
       );
-    else if (renderSlide === "2b")
-      node =
-        format === "li" ? (
-          <TemplateB_Square
-            numeralPos={numeralB}
-            onNumeralChange={setNumeralB}
-            stories={effectiveStories.slice(2, 4)}
-            tagline={issueData.tagline}
-            bgColor={bgFinal2b}
-            taglineFontSize={tagFs2b}
-            cta={slide2Cta}
-            logoLeft={slide2bLogoLeft}
-            issueNumber={issueData.number}
-            brandLong={issueData.brandLong}
-            date={issueData.date}
-          />
-        ) : (
-          <TemplateB_Rect
-            numeralPos={numeralB}
-            onNumeralChange={setNumeralB}
-            stories={effectiveStories.slice(0, 4)}
-            tagline={issueData.tagline}
-            bgColor={bgFinal2b}
-            taglineFontSize={tagFs2b}
-            cta={slide2Cta}
-            logoLeft={slide2bLogoLeft}
-            issueNumber={issueData.number}
-            brandLong={issueData.brandLong}
-            date={issueData.date}
-          />
-        );
+    }
     else if (renderSlide === "C")
       node = (
         <TemplateC
@@ -2399,15 +2503,15 @@ function OverviewCoversDevPage() {
           <PdfDownloadButton
             href={(() => {
               const sp = new URLSearchParams();
-              // IG 4:5 fits all 4 picked stories on Slide 2a, so the 3-slide
-              // carousel closes with a CTA panel. LI 1:1 fits only 2 stories
-              // per slide, so 2b is required to display stories 3–4 — the
-              // CTA panel would otherwise leave half the picked stories off
-              // the deliverable.
-              const slides = format === "li" ? "A,2a,2b" : "A,2a,C";
-              sp.set("slides", slides);
+              // Slide list grows with story count: ceil(N/2) inner slides
+              // for both formats; LI closes there, IG appends a CTA panel.
+              sp.set(
+                "slides",
+                computeSlideList(storyPicks.length, format).join(","),
+              );
               sp.set("fmt", format);
               sp.set("hero", heroSrc);
+              sp.set("subs", subscribeUrl);
               sp.set("n", String(issueData.number));
               sp.set("dt", issueData.date);
               sp.set("br", issueData.brand);
@@ -2416,6 +2520,7 @@ function OverviewCoversDevPage() {
               if (storyPicks.length > 0) {
                 sp.set("sp", JSON.stringify(storyPicks));
               }
+              sp.set("is", JSON.stringify(innerSlides));
               sp.set("ax", String(posA.x));
               sp.set("ay", String(posA.y));
               sp.set("az", String(posA.zoom));
@@ -2425,19 +2530,11 @@ function OverviewCoversDevPage() {
               sp.set("cx", String(posC.x));
               sp.set("cy", String(posC.y));
               sp.set("cz", String(posC.zoom));
-              sp.set("nafs", String(numeralA.fontSize));
-              sp.set("nadx", String(numeralA.dx));
-              sp.set("nady", String(numeralA.dy));
-              sp.set("nbfs", String(numeralB.fontSize));
-              sp.set("nbdx", String(numeralB.dx));
-              sp.set("nbdy", String(numeralB.dy));
               sp.set("tafs", String(taglineFsA));
               sp.set("tcfs", String(taglineFsC));
               if (slide1NumeralLeft) sp.set("s1l", "1");
               sp.set("s1nl", slide1NumeralLight ? "1" : "0");
               sp.set("s1no", String(slide1NumeralOpacity));
-              sp.set("s2al", slide2aLogoLeft ? "1" : "0");
-              sp.set("s2bl", slide2bLogoLeft ? "1" : "0");
               return `/api/tools/download-pdf?${sp.toString()}`;
             })()}
             filename={`intersect-issue-${issueData.number}-overview-${format}.pdf`}
@@ -2459,7 +2556,7 @@ function OverviewCoversDevPage() {
               onClick={() => setStoryPicks([])}
               className="text-xs underline opacity-70 hover:opacity-100 ml-auto"
             >
-              clear story picks ({storyPicks.length}/4)
+              clear story picks ({storyPicks.length}/{MAX_STORY_PICKS})
             </button>
           )}
         </div>
@@ -2476,7 +2573,7 @@ function OverviewCoversDevPage() {
         {curatorState.state === "loaded" && curatorState.entries && (
           <div className="flex flex-col gap-2">
             <div className="text-xs text-muted-foreground">
-              Pick up to 4 stories for the Slide 2 grid (click to toggle):
+              Pick up to {MAX_STORY_PICKS} stories — they fill {STORIES_PER_INNER} per inner slide (click to toggle):
             </div>
             <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
               {curatorState.entries.map((e) => {
@@ -2615,143 +2712,94 @@ function OverviewCoversDevPage() {
           />
         </div>
 
-        <div className="flex flex-col gap-2">
-          <CanvasFrame
-            label={
-              format === "li"
-                ? "Slide 2a — Inner cover · stories 1–2"
-                : "Slide 2a — Inner cover · square mark"
+        {innerSlides.map((slide, idx) => {
+          const cells = computeCells(
+            effectiveStories,
+            idx,
+            heroSrc,
+            subscribeUrl,
+            format,
+          );
+          const bgFinal = adjustLightness(
+            slide.bgColor ?? PALETTE.cream,
+            slide.bgLightness,
+          );
+          const slideLabel = `Slide ${idx + 2} (${idx === 0 ? "2a" : idx === 1 ? "2b" : `2${String.fromCharCode(99 + idx - 2)}`})`;
+          // Story-cell drag handler: maps cellIdx within this inner slide to
+          // its global pick index in storyPicks, then writes back.
+          const onCellDrag = (cellIdx: number, pos: ImagePos) => {
+            const globalIdx = idx * STORIES_PER_INNER + cellIdx;
+            if (globalIdx < storyPicks.length) {
+              updateStoryImagePos(globalIdx, pos);
             }
-          >
-            <TemplateB_Square
-              numeralPos={numeralA}
-              onNumeralChange={setNumeralA}
-              stories={
-                format === "li"
-                  ? effectiveStories.slice(0, 2)
-                  : effectiveStories.slice(0, 4)
-              }
-              tagline={issueData.tagline}
-              bgColor={bgFinal2a}
-              taglineFontSize={tagFs2a}
-              cta={slide2Cta}
-              logoLeft={slide2aLogoLeft}
-              issueNumber={issueData.number}
-              brandLong={issueData.brandLong}
-              date={issueData.date}
-            />
-          </CanvasFrame>
-          <DownloadButton href={buildDownloadHref("2a")} filename={`intersect-issue-${issueData.number}-inner-2a.png`} />
-          <div className="flex items-center gap-2 text-xs font-mono text-muted-foreground" style={{ width: DISPLAY_W }}>
-            <button
-              type="button"
-              onClick={() => setSlide2aLogoLeft(!slide2aLogoLeft)}
-              className="px-2 py-1 border border-border rounded hover:bg-muted"
-              title="Swap logo and numeral sides"
-            >
-              {slide2aLogoLeft ? "↔ Move logo to right" : "↔ Move logo to left"}
-            </button>
-            <span className="opacity-60">
-              logo currently {slide2aLogoLeft ? "left" : "right"}
-            </span>
-          </div>
-          <NumeralControls
-            label="Slide 2a · 74"
-            value={numeralA}
-            onChange={setNumeralA}
-            onReset={() => setNumeralA({ fontSize: 265, dx: -29, dy: -48 })}
-          />
-          <BgTaglineControls
-            label="Slide 2a"
-            bgColor={bg2a}
-            onBgColorChange={setBg2a}
-            bgLightness={bgL2a}
-            onBgLightnessChange={setBgL2a}
-            bgFinalColor={bgFinal2a}
-            taglineFontSize={tagFs2a}
-            onTaglineFontSizeChange={setTagFs2a}
-            onReset={() => {
-              setBg2a(null);
-              setBgL2a(0);
-              setTagFs2a(50);
-            }}
-          />
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <CanvasFrame
-            label={
-              format === "li"
-                ? "Slide 2b — Inner cover · stories 3–4"
-                : "Slide 2b — Inner cover · large rect logo"
-            }
-          >
-            {format === "li" ? (
-              <TemplateB_Square
-                numeralPos={numeralB}
-                onNumeralChange={setNumeralB}
-                stories={effectiveStories.slice(2, 4)}
-                tagline={issueData.tagline}
-                bgColor={bgFinal2b}
-                taglineFontSize={tagFs2b}
-                cta={slide2Cta}
-                logoLeft={slide2bLogoLeft}
-                issueNumber={issueData.number}
-                brandLong={issueData.brandLong}
-                date={issueData.date}
+          };
+          return (
+            <div className="flex flex-col gap-2" key={`inner-${idx}`}>
+              <CanvasFrame label={`${slideLabel} — Inner cover`}>
+                <TemplateB_Cells
+                  numeralPos={slide.numeral}
+                  onNumeralChange={(n) => updateInner(idx, { numeral: n })}
+                  cells={cells}
+                  tagline={issueData.tagline}
+                  bgColor={bgFinal}
+                  taglineFontSize={slide.taglineFs}
+                  cta={slide2Cta}
+                  logoLeft={slide.logoLeft}
+                  issueNumber={issueData.number}
+                  brandLong={issueData.brandLong}
+                  date={issueData.date}
+                  format={format}
+                  onCellImagePosChange={onCellDrag}
+                />
+              </CanvasFrame>
+              <DownloadButton
+                href={buildDownloadHref(`i${idx}`)}
+                filename={`intersect-issue-${issueData.number}-inner-${idx}.png`}
               />
-            ) : (
-              <TemplateB_Rect
-                numeralPos={numeralB}
-                onNumeralChange={setNumeralB}
-                stories={effectiveStories.slice(0, 4)}
-                tagline={issueData.tagline}
-                bgColor={bgFinal2b}
-                taglineFontSize={tagFs2b}
-                cta={slide2Cta}
-                logoLeft={slide2bLogoLeft}
-                issueNumber={issueData.number}
-                brandLong={issueData.brandLong}
-                date={issueData.date}
+              <div
+                className="flex items-center gap-2 text-xs font-mono text-muted-foreground"
+                style={{ width: DISPLAY_W }}
+              >
+                <button
+                  type="button"
+                  onClick={() => updateInner(idx, { logoLeft: !slide.logoLeft })}
+                  className="px-2 py-1 border border-border rounded hover:bg-muted"
+                  title="Swap logo and numeral sides"
+                >
+                  {slide.logoLeft ? "↔ Move logo to right" : "↔ Move logo to left"}
+                </button>
+                <span className="opacity-60">
+                  logo currently {slide.logoLeft ? "left" : "right"}
+                </span>
+              </div>
+              <NumeralControls
+                label={`${slideLabel} · numeral`}
+                value={slide.numeral}
+                onChange={(n) => updateInner(idx, { numeral: n })}
+                onReset={() =>
+                  updateInner(idx, { numeral: DEFAULT_INNER.numeral })
+                }
               />
-            )}
-          </CanvasFrame>
-          <DownloadButton href={buildDownloadHref("2b")} filename={`intersect-issue-${issueData.number}-inner-2b.png`} />
-          <div className="flex items-center gap-2 text-xs font-mono text-muted-foreground" style={{ width: DISPLAY_W }}>
-            <button
-              type="button"
-              onClick={() => setSlide2bLogoLeft(!slide2bLogoLeft)}
-              className="px-2 py-1 border border-border rounded hover:bg-muted"
-              title="Swap logo and numeral sides"
-            >
-              {slide2bLogoLeft ? "↔ Move logo to right" : "↔ Move logo to left"}
-            </button>
-            <span className="opacity-60">
-              logo currently {slide2bLogoLeft ? "left" : "right"}
-            </span>
-          </div>
-          <NumeralControls
-            label="Slide 2b · 74"
-            value={numeralB}
-            onChange={setNumeralB}
-            onReset={() => setNumeralB({ fontSize: 225, dx: -11, dy: -41 })}
-          />
-          <BgTaglineControls
-            label="Slide 2b"
-            bgColor={bg2b}
-            onBgColorChange={setBg2b}
-            bgLightness={bgL2b}
-            onBgLightnessChange={setBgL2b}
-            bgFinalColor={bgFinal2b}
-            taglineFontSize={tagFs2b}
-            onTaglineFontSizeChange={setTagFs2b}
-            onReset={() => {
-              setBg2b(null);
-              setBgL2b(0);
-              setTagFs2b(44);
-            }}
-          />
-        </div>
+              <BgTaglineControls
+                label={slideLabel}
+                bgColor={slide.bgColor}
+                onBgColorChange={(c) => updateInner(idx, { bgColor: c })}
+                bgLightness={slide.bgLightness}
+                onBgLightnessChange={(l) => updateInner(idx, { bgLightness: l })}
+                bgFinalColor={bgFinal}
+                taglineFontSize={slide.taglineFs}
+                onTaglineFontSizeChange={(t) => updateInner(idx, { taglineFs: t })}
+                onReset={() =>
+                  updateInner(idx, {
+                    bgColor: DEFAULT_INNER.bgColor,
+                    bgLightness: DEFAULT_INNER.bgLightness,
+                    taglineFs: DEFAULT_INNER.taglineFs,
+                  })
+                }
+              />
+            </div>
+          );
+        })}
 
         <div className="flex flex-col gap-2">
           <CanvasFrame label="Slide 3 — CTA (full-bleed)">

--- a/src/app/dashboard/tools/cover-generator/page.tsx
+++ b/src/app/dashboard/tools/cover-generator/page.tsx
@@ -534,9 +534,11 @@ function NumberStepper({
 function PdfDownloadButton({
   href,
   filename,
+  slideCount,
 }: {
   href: string;
   filename: string;
+  slideCount: number;
 }) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -571,15 +573,15 @@ function PdfDownloadButton({
         onClick={onClick}
         disabled={busy}
         className="px-3 py-1.5 border border-border rounded text-xs hover:bg-muted disabled:opacity-50 flex items-center gap-1.5"
-        title="Render all 3 slides + assemble into a single PDF (LinkedIn carousel)"
+        title={`Render all ${slideCount} slides + assemble into a single PDF`}
       >
         {busy ? (
           <>
             <span className="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
-            Rendering PDF (~30s)…
+            Rendering PDF (~{slideCount * 6}s)…
           </>
         ) : (
-          <>↓ Download PDF (3 slides)</>
+          <>↓ Download PDF ({slideCount} slides)</>
         )}
       </button>
       {err && <span className="text-[10px] text-red-600">{err}</span>}
@@ -2131,6 +2133,12 @@ function OverviewCoversDevPage() {
       innerSlides.map((s, j) => (j === idx ? { ...s, ...patch } : s)),
     );
   };
+  // Numeral edits propagate to ALL inner slides so the issue number stays
+  // visually consistent across the carousel — adjusting it on one slide
+  // updates every slide.
+  const setSharedNumeral = (numeral: InnerSlideState["numeral"]) => {
+    setInnerSlides(innerSlides.map((s) => ({ ...s, numeral })));
+  };
 
   const [upscale, setUpscale] = useState<UpscaleStatus>({ state: "idle" });
   const [taglineFsA, setTaglineFsA] = useLocalStorage<number>(
@@ -2508,12 +2516,13 @@ function OverviewCoversDevPage() {
       <div>
         <h1 className="text-2xl font-bold mb-1">Overview Cover Generator</h1>
         <p className="text-sm text-muted-foreground">
-          Render the 3 carousel slides for an Intersect newsletter Overview
-          post. Instagram 4:5 (1080×1350) or LinkedIn 1:1 (1080×1080) — toggle
-          below. Drag images to reposition, drag the 74 to nudge it, tune
-          colors and tagline sizes per slide. Click <strong>↓ Download PNG</strong>{" "}
-          for individual slides or <strong>↓ Download PDF</strong> for the
-          full 3-slide carousel.
+          Render the carousel slides for an Intersect newsletter Overview post.
+          Inner slides scale with the number of picked stories — 2 stories
+          per inner slide. Instagram 4:5 (1080×1350) or LinkedIn 1:1
+          (1080×1080) — toggle below. Drag images to reposition, drag the
+          numeral to nudge it, tune colors and tagline sizes per slide.
+          Click <strong>↓ Download PNG</strong> for individual slides or
+          {" "}<strong>↓ Download PDF</strong> for the full carousel.
         </p>
       </div>
 
@@ -2602,6 +2611,7 @@ function OverviewCoversDevPage() {
               return `/api/tools/download-pdf?${sp.toString()}`;
             })()}
             filename={`intersect-issue-${issueData.number}-overview-${format}.pdf`}
+            slideCount={computeSlideList(storyPicks.length, format).length}
           />
           {curatorState.state === "loaded" && curatorState.issue && (
             <span className="text-xs text-muted-foreground">
@@ -2802,7 +2812,7 @@ function OverviewCoversDevPage() {
               <CanvasFrame label={`${slideLabel} — Inner cover`}>
                 <TemplateB_Cells
                   numeralPos={slide.numeral}
-                  onNumeralChange={(n) => updateInner(idx, { numeral: n })}
+                  onNumeralChange={setSharedNumeral}
                   cells={cells}
                   tagline={issueData.tagline}
                   bgColor={bgFinal}
@@ -2837,12 +2847,10 @@ function OverviewCoversDevPage() {
                 </span>
               </div>
               <NumeralControls
-                label={`${slideLabel} · numeral`}
+                label={`${slideLabel} · numeral (shared across all inner slides)`}
                 value={slide.numeral}
-                onChange={(n) => updateInner(idx, { numeral: n })}
-                onReset={() =>
-                  updateInner(idx, { numeral: defaultInner(format).numeral })
-                }
+                onChange={setSharedNumeral}
+                onReset={() => setSharedNumeral(defaultInner(format).numeral)}
               />
               <BgTaglineControls
                 label={slideLabel}

--- a/src/app/dashboard/tools/cover-generator/page.tsx
+++ b/src/app/dashboard/tools/cover-generator/page.tsx
@@ -108,6 +108,17 @@ const DEFAULT_INNER: InnerSlideState = {
   taglineFs: 50,
   logoLeft: true,
 };
+// LinkedIn-specific defaults — keeps IG defaults frozen above.
+const DEFAULT_INNER_LI: InnerSlideState = {
+  numeral: { fontSize: 200, dx: -29, dy: -48 },
+  bgColor: null,
+  bgLightness: 0,
+  taglineFs: 50,
+  logoLeft: true,
+};
+function defaultInner(format: "li" | "ig"): InnerSlideState {
+  return format === "li" ? DEFAULT_INNER_LI : DEFAULT_INNER;
+}
 
 // Discriminated cell type for the 2-cell inner-slide grid. Subscribe cell is
 // the orphan-filler when picks.length is odd (LI) or as a graceful gap-filler
@@ -1378,15 +1389,19 @@ function CellRenderer({
   cell,
   cellIdx,
   onImagePosChange,
-  cellAspect,
+  cellW,
+  cellH,
+  titleFontSize = 36,
 }: {
   cell: Cell;
   cellIdx: number;
   onImagePosChange?: (cellIdx: number, pos: ImagePos) => void;
-  /** CSS aspect-ratio applied to both story and subscribe cells so they match
-   *  in the grid. Format-driven: LI side-by-side uses 16/11, IG vertical
-   *  stack uses 16/9 (less-tall, more horizontal frames). */
-  cellAspect: string;
+  /** Explicit width + height in slide-canvas pixels. Computed by parent so
+   *  the cell doesn't fight grid/flex stretching. */
+  cellW: number;
+  cellH: number;
+  /** Story title overlay font size. Format-driven (LI smaller than IG). */
+  titleFontSize?: number;
 }) {
   if (cell.kind === "subscribe") {
     return (
@@ -1395,7 +1410,9 @@ function CellRenderer({
           position: "relative",
           overflow: "hidden",
           background: "#222",
-          aspectRatio: cellAspect,
+          width: cellW,
+          height: cellH,
+          borderRadius: 3,
         }}
       >
         <img
@@ -1488,9 +1505,10 @@ function CellRenderer({
         position: "relative",
         overflow: "hidden",
         background: "#222",
-        // Enforce aspect ratio so portrait-ish photos don't get squished into
-        // wide banners by flex:1 layout. Matches the original cell shape.
-        aspectRatio: "16 / 9.35",
+        // Explicit width + height (computed from canvas + inset by parent)
+        // so cells don't fight grid stretching.
+        width: cellW,
+        height: cellH,
         borderRadius: 3,
       }}
     >
@@ -1540,7 +1558,7 @@ function CellRenderer({
           textAlign: "center",
           fontFamily: '"Noto Sans", system-ui, sans-serif',
           fontWeight: 400,
-          fontSize: 36,
+          fontSize: titleFontSize,
           lineHeight: 1.1,
           letterSpacing: 0.1,
           pointerEvents: "none",
@@ -1670,8 +1688,18 @@ function TemplateB_Cells({
   // LI 1:1 keeps cells side-by-side with the original tighter inset.
   const isLI = format === "li";
   const inset = isLI ? 60 : 120;
-  const topInset = isLI ? 30 : 50;
+  const topInset = isLI ? 60 : 50;
   const ROW_H = isLI ? 192 : 144;
+  // Compute explicit cell dimensions so aspectRatio is honored regardless of
+  // grid stretching. LI: 2 side-by-side, IG: 1 column. Width derives from
+  // canvas width and inset; height = width × aspectFactor.
+  const GAP = 16;
+  const cellW = isLI
+    ? (size.w - inset * 2 - GAP) / 2
+    : size.w - inset * 2;
+  const cellAspectStr = isLI ? "1 / 1" : "16 / 9.35";
+  const [aw, ah] = cellAspectStr.split(" / ").map(Number);
+  const cellH = (cellW * ah) / aw;
   const bgIsLight = hexLuminance(bgColor) > 0.55;
   const fg = bgIsLight ? PALETTE.ink : "#f5f4ee";
   const fgSoft = bgIsLight ? PALETTE.inkSoft : "rgba(245,244,238,0.7)";
@@ -1757,7 +1785,7 @@ function TemplateB_Cells({
         )}
       </div>
 
-      <div style={{ height: topInset + ROW_H + topInset - 5, flexShrink: 0 }} />
+      <div style={{ height: topInset + ROW_H + topInset + (isLI ? -75 : -5), flexShrink: 0 }} />
 
       <div
         style={{
@@ -1766,7 +1794,7 @@ function TemplateB_Cells({
           // LI: cells side-by-side. IG: stacked vertically (one above the
           // other) so each cell becomes a tall near-square frame.
           gridTemplateColumns: isLI ? "1fr 1fr" : "1fr",
-          gridTemplateRows: isLI ? "1fr" : "1fr 1fr",
+          gridTemplateRows: isLI ? "auto" : "1fr 1fr",
           gap: 16,
           padding: `0 ${inset}px`,
           alignContent: "center",
@@ -1778,31 +1806,36 @@ function TemplateB_Cells({
             cell={cell}
             cellIdx={i}
             onImagePosChange={onCellImagePosChange}
+            cellW={cellW}
+            cellH={cellH}
+            titleFontSize={isLI ? 22 : 36}
           />
         ))}
       </div>
 
       <div
         style={{
-          padding: `${inset}px ${inset}px ${inset}px`,
+          padding: `${inset}px ${inset}px ${isLI ? 28 : inset}px`,
           display: "flex",
           flexDirection: "column",
           gap: 28,
           flexShrink: 0,
         }}
       >
-        <div
-          style={{
-            fontFamily: '"Noto Serif", Georgia, serif',
-            fontStyle: "italic",
-            fontSize: taglineFontSize,
-            color: fg,
-            lineHeight: 1.18,
-            letterSpacing: -0.5,
-          }}
-        >
-          {tagline}
-        </div>
+        {!isLI && (
+          <div
+            style={{
+              fontFamily: '"Noto Serif", Georgia, serif',
+              fontStyle: "italic",
+              fontSize: taglineFontSize,
+              color: fg,
+              lineHeight: 1.18,
+              letterSpacing: -0.5,
+            }}
+          >
+            {tagline}
+          </div>
+        )}
         <div
           style={{
             display: "flex",
@@ -1810,12 +1843,12 @@ function TemplateB_Cells({
             alignItems: "baseline",
             paddingTop: 22,
             borderTop: `1px solid ${borderTop}`,
-            fontSize: 22,
+            fontSize: isLI ? 30 : 22,
             letterSpacing: 3,
           }}
         >
           <div style={{ color: fgSoft }}>{date}</div>
-          <div style={{ color: fg, fontWeight: 700 }}>{cta}</div>
+          <div style={{ color: fg, fontWeight: 700, opacity: isLI ? 0.5 : 1 }}>{cta}</div>
         </div>
       </div>
     </div>
@@ -2127,7 +2160,7 @@ function OverviewCoversDevPage() {
     () => (format === "li" ? SIZE_LI : SIZE_IG),
     [format],
   );
-  const liUrl = `intersect.art/issues/${issueNumber}`;
+  const liUrl = `theintersect.art/issues/${issueNumber}`;
   const slide1Cta = format === "li" ? liUrl : "READ IN BIO →";
   const slide2Cta = format === "li" ? liUrl : "LINK IN BIO →";
   const slide3Cta =
@@ -2161,7 +2194,7 @@ function OverviewCoversDevPage() {
     if (innerSlides.length < requiredInnerCount) {
       const next = [...innerSlides];
       while (next.length < requiredInnerCount) {
-        next.push({ ...DEFAULT_INNER });
+        next.push({ ...defaultInner(format) });
       }
       setInnerSlides(next);
     }
@@ -2397,7 +2430,7 @@ function OverviewCoversDevPage() {
       );
     else if (renderSlide.match(/^i(\d+)$/)) {
       const innerIdx = Number(renderSlide.slice(1));
-      const slideState = innerSlides[innerIdx] ?? DEFAULT_INNER;
+      const slideState = innerSlides[innerIdx] ?? defaultInner(format);
       const cells = computeCells(
         effectiveStories,
         innerIdx,
@@ -2808,7 +2841,7 @@ function OverviewCoversDevPage() {
                 value={slide.numeral}
                 onChange={(n) => updateInner(idx, { numeral: n })}
                 onReset={() =>
-                  updateInner(idx, { numeral: DEFAULT_INNER.numeral })
+                  updateInner(idx, { numeral: defaultInner(format).numeral })
                 }
               />
               <BgTaglineControls
@@ -2822,9 +2855,9 @@ function OverviewCoversDevPage() {
                 onTaglineFontSizeChange={(t) => updateInner(idx, { taglineFs: t })}
                 onReset={() =>
                   updateInner(idx, {
-                    bgColor: DEFAULT_INNER.bgColor,
-                    bgLightness: DEFAULT_INNER.bgLightness,
-                    taglineFs: DEFAULT_INNER.taglineFs,
+                    bgColor: defaultInner(format).bgColor,
+                    bgLightness: defaultInner(format).bgLightness,
+                    taglineFs: defaultInner(format).taglineFs,
                   })
                 }
               />

--- a/src/app/dashboard/tools/cover-generator/page.tsx
+++ b/src/app/dashboard/tools/cover-generator/page.tsx
@@ -102,7 +102,7 @@ type InnerSlideState = {
   logoLeft: boolean;
 };
 const DEFAULT_INNER: InnerSlideState = {
-  numeral: { fontSize: 245, dx: -29, dy: -48 },
+  numeral: { fontSize: 155, dx: -29, dy: -48 },
   bgColor: null,
   bgLightness: 0,
   taglineFs: 50,
@@ -1378,10 +1378,15 @@ function CellRenderer({
   cell,
   cellIdx,
   onImagePosChange,
+  cellAspect,
 }: {
   cell: Cell;
   cellIdx: number;
   onImagePosChange?: (cellIdx: number, pos: ImagePos) => void;
+  /** CSS aspect-ratio applied to both story and subscribe cells so they match
+   *  in the grid. Format-driven: LI side-by-side uses 16/11, IG vertical
+   *  stack uses 16/9 (less-tall, more horizontal frames). */
+  cellAspect: string;
 }) {
   if (cell.kind === "subscribe") {
     return (
@@ -1390,6 +1395,7 @@ function CellRenderer({
           position: "relative",
           overflow: "hidden",
           background: "#222",
+          aspectRatio: cellAspect,
         }}
       >
         <img
@@ -1401,7 +1407,7 @@ function CellRenderer({
             width: "100%",
             height: "100%",
             objectFit: "cover",
-            opacity: 0.55,
+            opacity: 0.75,
           }}
         />
         <div
@@ -1409,7 +1415,7 @@ function CellRenderer({
             position: "absolute",
             inset: 0,
             background:
-              "linear-gradient(to bottom, rgba(0,0,0,0.35) 0%, rgba(0,0,0,0.85) 100%)",
+              "linear-gradient(to bottom, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.55) 100%)",
           }}
         />
         <div
@@ -1418,46 +1424,55 @@ function CellRenderer({
             inset: 0,
             display: "flex",
             flexDirection: "column",
-            justifyContent: "center",
+            justifyContent: "space-between",
             alignItems: "center",
             padding: 24,
             color: "#fff",
             textAlign: "center",
             fontFamily: '"Noto Sans", system-ui, sans-serif',
-            gap: 10,
           }}
         >
           <div
             style={{
-              fontSize: 14,
+              fontSize: 32,
+              fontWeight: 300,
               letterSpacing: 4,
               opacity: 0.7,
             }}
           >
-            ENJOYED THIS ISSUE?
+            ENJOYING THIS ISSUE?
           </div>
           <div
             style={{
-              fontFamily: '"Noto Serif", Georgia, serif',
-              fontStyle: "italic",
-              fontSize: 32,
-              lineHeight: 1.15,
-              fontWeight: 400,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: 10,
             }}
           >
-            Subscribe to The Intersect
-          </div>
-          <div
-            style={{
-              marginTop: 6,
-              fontSize: 14,
-              letterSpacing: 3,
-              fontWeight: 700,
-            }}
-          >
-            {cell.format === "li"
-              ? cell.subscribeUrl.toUpperCase()
-              : "LINK IN BIO →"}
+            <div
+              style={{
+                fontFamily: '"Noto Serif", Georgia, serif',
+                fontStyle: "italic",
+                fontSize: 54,
+                lineHeight: 1.15,
+                fontWeight: 400,
+              }}
+            >
+              Subscribe to The Intersect
+            </div>
+            <div
+              style={{
+                marginTop: 6,
+                fontSize: 24,
+                letterSpacing: 3,
+                fontWeight: 700,
+              }}
+            >
+              {cell.format === "li"
+                ? cell.subscribeUrl.toUpperCase()
+                : "LINK IN BIO →"}
+            </div>
           </div>
         </div>
       </div>
@@ -1475,7 +1490,8 @@ function CellRenderer({
         background: "#222",
         // Enforce aspect ratio so portrait-ish photos don't get squished into
         // wide banners by flex:1 layout. Matches the original cell shape.
-        aspectRatio: "16 / 11",
+        aspectRatio: "16 / 9.35",
+        borderRadius: 3,
       }}
     >
       {story.imageUrl ? (
@@ -1517,19 +1533,32 @@ function CellRenderer({
           left: 0,
           right: 0,
           bottom: 0,
-          padding: "60px 18px 14px",
+          padding: "60px 32px 20px 26px",
           background:
             "linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0) 100%)",
           color: "#fff",
+          textAlign: "center",
           fontFamily: '"Noto Sans", system-ui, sans-serif',
           fontWeight: 400,
-          fontSize: 19,
-          lineHeight: 1.3,
+          fontSize: 36,
+          lineHeight: 1.1,
           letterSpacing: 0.1,
           pointerEvents: "none",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "flex-end",
         }}
       >
-        {story.title}
+        <div
+          style={{
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+          }}
+        >
+          {story.title}
+        </div>
       </div>
     </div>
   );
@@ -1641,7 +1670,8 @@ function TemplateB_Cells({
   // LI 1:1 keeps cells side-by-side with the original tighter inset.
   const isLI = format === "li";
   const inset = isLI ? 60 : 120;
-  const ROW_H = isLI ? 240 : 180;
+  const topInset = isLI ? 30 : 50;
+  const ROW_H = isLI ? 192 : 144;
   const bgIsLight = hexLuminance(bgColor) > 0.55;
   const fg = bgIsLight ? PALETTE.ink : "#f5f4ee";
   const fgSoft = bgIsLight ? PALETTE.inkSoft : "rgba(245,244,238,0.7)";
@@ -1664,7 +1694,7 @@ function TemplateB_Cells({
       <div
         style={{
           position: "absolute",
-          top: inset,
+          top: topInset,
           left: inset,
           right: inset,
           height: ROW_H,
@@ -1683,6 +1713,7 @@ function TemplateB_Cells({
                 width: ROW_H,
                 objectFit: "contain",
                 opacity: 0.5,
+                marginLeft: -2,
                 filter: bgIsLight
                   ? "brightness(0)"
                   : "brightness(0) invert(1)",
@@ -1726,7 +1757,7 @@ function TemplateB_Cells({
         )}
       </div>
 
-      <div style={{ height: inset + ROW_H + inset, flexShrink: 0 }} />
+      <div style={{ height: topInset + ROW_H + topInset - 5, flexShrink: 0 }} />
 
       <div
         style={{
@@ -1736,7 +1767,7 @@ function TemplateB_Cells({
           // other) so each cell becomes a tall near-square frame.
           gridTemplateColumns: isLI ? "1fr 1fr" : "1fr",
           gridTemplateRows: isLI ? "1fr" : "1fr 1fr",
-          gap: 12,
+          gap: 16,
           padding: `0 ${inset}px`,
           alignContent: "center",
         }}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -289,3 +289,16 @@
 .carousel-dark-scroll::-webkit-scrollbar-thumb:hover {
   background: #71717a;
 }
+
+/* Checkerboard background — used in logo upload tiles for full-color logos
+   so transparency is visible regardless of light/dark theme. */
+.bg-checker {
+  background-color: #ffffff;
+  background-image:
+    linear-gradient(45deg, #d4d4d8 25%, transparent 25%),
+    linear-gradient(-45deg, #d4d4d8 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #d4d4d8 75%),
+    linear-gradient(-45deg, transparent 75%, #d4d4d8 75%);
+  background-size: 16px 16px;
+  background-position: 0 0, 0 8px, 8px -8px, -8px 0px;
+}

--- a/src/components/brands/logo-manager.tsx
+++ b/src/components/brands/logo-manager.tsx
@@ -11,24 +11,30 @@ import { cn } from "@/lib/utils";
 import type { Brand } from "@/lib/airtable/types";
 
 export type LogoSlot =
+  | "color-square"
   | "light-square"
   | "dark-square"
+  | "color-rect"
   | "light-rect"
   | "dark-rect";
+
+type PreviewBg = "light" | "dark" | "checker";
 
 interface SlotDef {
   slot: LogoSlot;
   label: string;
   helper: string;
-  /** Background swatch behind the preview — opposite of the logo's intended bg. */
-  previewBg: "light" | "dark";
+  /** Background swatch behind the preview. */
+  previewBg: PreviewBg;
   /** Aspect class (Tailwind) for the drop target. */
   aspect: string;
   /** Map to the camelCase Brand field that stores this slot's URL. */
   brandField: keyof Pick<
     Brand,
+    | "logoColorSquare"
     | "logoTransparentDark" // light-square (logo art is dark, lives on light bg)
     | "logoTransparentLight" // dark-square (logo art is light, lives on dark bg)
+    | "logoColorRect"
     | "logoRectangularLight" // light-rect (wordmark for light bg)
     | "logoRectangularDark" // dark-rect (wordmark for dark bg)
   >;
@@ -36,33 +42,49 @@ interface SlotDef {
 
 const SLOTS: SlotDef[] = [
   {
+    slot: "color-square",
+    label: "Color",
+    helper: "Full-color square logo. Used in the brand switcher.",
+    previewBg: "checker",
+    aspect: "aspect-square",
+    brandField: "logoColorSquare",
+  },
+  {
     slot: "light-square",
-    label: "Square — Light Background",
-    helper: "Dark/black logo art for placement on light backgrounds.",
+    label: "On Light",
+    helper: "Dark/black logo art for light backgrounds.",
     previewBg: "light",
     aspect: "aspect-square",
     brandField: "logoTransparentDark",
   },
   {
     slot: "dark-square",
-    label: "Square — Dark Background",
-    helper: "Light/white logo art for placement on dark backgrounds.",
+    label: "On Dark",
+    helper: "Light/white logo art for dark backgrounds.",
     previewBg: "dark",
     aspect: "aspect-square",
     brandField: "logoTransparentLight",
   },
   {
+    slot: "color-rect",
+    label: "Color",
+    helper: "Full-color rectangular wordmark.",
+    previewBg: "checker",
+    aspect: "aspect-[2/1]",
+    brandField: "logoColorRect",
+  },
+  {
     slot: "light-rect",
-    label: "Rectangular — Light Background",
-    helper: "Wordmark or horizontal logo for use over light backgrounds.",
+    label: "On Light",
+    helper: "Wordmark for light backgrounds.",
     previewBg: "light",
     aspect: "aspect-[2/1]",
     brandField: "logoRectangularLight",
   },
   {
     slot: "dark-rect",
-    label: "Rectangular — Dark Background",
-    helper: "Wordmark or horizontal logo for use over dark backgrounds.",
+    label: "On Dark",
+    helper: "Wordmark for dark backgrounds.",
     previewBg: "dark",
     aspect: "aspect-[2/1]",
     brandField: "logoRectangularDark",
@@ -76,6 +98,17 @@ const ALLOWED_MIME = [
   "image/webp",
   "image/svg+xml",
 ];
+
+function previewBgClasses(previewBg: PreviewBg): string {
+  if (previewBg === "light") return "bg-white border-zinc-300";
+  if (previewBg === "dark") return "bg-zinc-900 border-zinc-700";
+  return "bg-checker border-zinc-300";
+}
+
+function placeholderTextClass(previewBg: PreviewBg): string {
+  if (previewBg === "dark") return "text-zinc-400";
+  return "text-zinc-500";
+}
 
 function LogoDropZone({
   brand,
@@ -149,24 +182,22 @@ function LogoDropZone({
   };
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-baseline justify-between gap-2">
-        <Label className="text-xs font-medium text-foreground">{def.label}</Label>
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-1">
+        <Label className="text-[11px] font-medium text-foreground">{def.label}</Label>
         {currentUrl && (
           <Button
             variant="ghost"
             size="sm"
-            className="h-6 text-[11px] px-2 text-muted-foreground hover:text-destructive"
+            className="h-5 w-5 p-0 text-muted-foreground hover:text-destructive"
             onClick={handleDelete}
             disabled={!!busy}
+            title="Remove"
           >
             {busy === "delete" ? (
               <Loader2 className="h-3 w-3 animate-spin" />
             ) : (
-              <>
-                <Trash2 className="h-3 w-3 mr-1" />
-                Remove
-              </>
+              <Trash2 className="h-3 w-3" />
             )}
           </Button>
         )}
@@ -181,11 +212,9 @@ function LogoDropZone({
         onDragLeave={() => setDragOver(false)}
         onDrop={onDrop}
         className={cn(
-          "block w-full rounded-lg border-2 border-dashed transition-colors cursor-pointer overflow-hidden relative",
+          "block w-full rounded-md border-2 border-dashed transition-colors cursor-pointer overflow-hidden relative",
           def.aspect,
-          def.previewBg === "light"
-            ? "bg-white border-zinc-300"
-            : "bg-zinc-900 border-zinc-700",
+          previewBgClasses(def.previewBg),
           dragOver && "border-primary ring-2 ring-primary/40",
           busy && "opacity-60 cursor-wait"
         )}
@@ -205,7 +234,7 @@ function LogoDropZone({
         />
 
         {currentUrl ? (
-          <div className="absolute inset-0 flex items-center justify-center p-4">
+          <div className="absolute inset-0 flex items-center justify-center p-2">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={currentUrl}
@@ -216,39 +245,38 @@ function LogoDropZone({
         ) : (
           <div
             className={cn(
-              "absolute inset-0 flex flex-col items-center justify-center text-center p-3",
-              def.previewBg === "light" ? "text-zinc-500" : "text-zinc-400"
+              "absolute inset-0 flex flex-col items-center justify-center text-center p-2",
+              placeholderTextClass(def.previewBg)
             )}
           >
-            <ImageIcon className="h-6 w-6 mb-1.5 opacity-60" />
-            <p className="text-xs font-medium">Drag &amp; drop</p>
-            <p className="text-[10px] opacity-70">or click to browse</p>
-            <p className="text-[10px] mt-1 opacity-50">PNG, JPG, WEBP, SVG &middot; max 5MB</p>
+            <ImageIcon className="h-4 w-4 mb-0.5 opacity-60" />
+            <p className="text-[10px] font-medium leading-tight">Drop image</p>
+            <p className="text-[9px] opacity-70 leading-tight">or click</p>
           </div>
         )}
 
         {busy === "upload" && (
           <div className="absolute inset-0 bg-background/70 flex items-center justify-center">
-            <Loader2 className="h-5 w-5 animate-spin text-primary" />
+            <Loader2 className="h-4 w-4 animate-spin text-primary" />
           </div>
         )}
       </label>
 
-      <div className="flex items-center justify-between gap-2">
-        <p className="text-[10px] text-muted-foreground leading-tight">{def.helper}</p>
+      <div className="flex items-center justify-between gap-1 min-h-[18px]">
+        <p className="text-[9px] text-muted-foreground leading-tight line-clamp-2">{def.helper}</p>
         {currentUrl && (
           <Button
             variant="ghost"
             size="sm"
-            className="h-6 text-[11px] px-2 text-muted-foreground"
+            className="h-5 w-5 p-0 shrink-0 text-muted-foreground"
             onClick={(e) => {
               e.preventDefault();
               inputRef.current?.click();
             }}
             disabled={!!busy}
+            title="Replace"
           >
-            <Upload className="h-3 w-3 mr-1" />
-            Replace
+            <Upload className="h-3 w-3" />
           </Button>
         )}
       </div>
@@ -260,6 +288,9 @@ export function LogoManager({ brand }: { brand: Brand }) {
   const queryClient = useQueryClient();
   const refresh = () => queryClient.invalidateQueries({ queryKey: ["brands"] });
 
+  const squareSlots = SLOTS.filter((s) => s.aspect === "aspect-square");
+  const rectSlots = SLOTS.filter((s) => s.aspect === "aspect-[2/1]");
+
   return (
     <Card>
       <CardContent className="p-5">
@@ -270,20 +301,43 @@ export function LogoManager({ brand }: { brand: Brand }) {
           </Label>
         </div>
         <p className="text-xs text-muted-foreground mb-4">
-          Upload square and rectangular logo variants for use across cover slides,
-          carousels, and other generated assets. Each slot is paired with a
-          contrasting preview background so you can verify legibility.
+          Upload color, light-bg, and dark-bg variants for both square and rectangular shapes.
+          The color square is used in the brand switcher; the transparent variants are used on
+          generated cover slides and carousels.
         </p>
 
-        <div className="grid gap-4 sm:grid-cols-2">
-          {SLOTS.map((def) => (
-            <LogoDropZone
-              key={def.slot}
-              brand={brand}
-              def={def}
-              onChanged={refresh}
-            />
-          ))}
+        <div className="space-y-5">
+          <div>
+            <Label className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-2 block">
+              Square (1:1)
+            </Label>
+            <div className="grid grid-cols-3 gap-3">
+              {squareSlots.map((def) => (
+                <LogoDropZone
+                  key={def.slot}
+                  brand={brand}
+                  def={def}
+                  onChanged={refresh}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <Label className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-2 block">
+              Rectangular (2:1)
+            </Label>
+            <div className="grid grid-cols-3 gap-3">
+              {rectSlots.map((def) => (
+                <LogoDropZone
+                  key={def.slot}
+                  brand={brand}
+                  def={def}
+                  onChanged={refresh}
+                />
+              ))}
+            </div>
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/src/lib/airtable/types.ts
+++ b/src/lib/airtable/types.ts
@@ -47,6 +47,8 @@ export interface Brand {
   lnkBioClientSecretLabel?: string | null;
   /** When true, source images outside a platform's valid aspect range are outpainted (via Replicate Bria) to the nearest valid ratio instead of center-cropped. Preserves all original detail; costs ~$0.02–0.04/image. Editorial brands on; art brands off. */
   outpaintInsteadOfCrop?: boolean;
+  /** Public URL surfaced as the destination of subscribe CTAs (e.g. cover-generator orphan card on LinkedIn slides). Empty string when not configured — subscribe cells fall back to a generic copy. */
+  subscribeUrl?: string;
   status: "Active" | "Inactive";
 }
 

--- a/src/lib/airtable/types.ts
+++ b/src/lib/airtable/types.ts
@@ -29,6 +29,10 @@ export interface Brand {
   logoRectangularLight: string | null;
   /** Vercel Blob URL for wordmark/horizontal logo for use over dark backgrounds. */
   logoRectangularDark: string | null;
+  /** Vercel Blob URL for full-color square logo. Used in the brand switcher and anywhere a recognizable color mark is preferred over the B&W transparents. */
+  logoColorSquare: string | null;
+  /** Vercel Blob URL for full-color rectangular/wordmark logo. */
+  logoColorRect: string | null;
   /** Per-brand tone dimension settings (8 dimensions, 1-10 scale each). */
   toneDimensions?: ToneDimensions;
   /** Short additional tone notes (1-2 sentences). */

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -111,6 +111,33 @@ export async function generatePosts(
   return parsed as { posts: GeneratedPost[] };
 }
 
+/**
+ * Generate a single short text response (no JSON, no posts array).
+ * Used for taglines, headlines, and other one-liner outputs.
+ */
+export async function generateText(
+  systemPrompt: string,
+  userPrompt: string,
+  config: AnthropicConfig,
+  options?: { maxTokens?: number; temperature?: number }
+): Promise<string> {
+  const client = new Anthropic({ apiKey: config.apiKey });
+
+  const response = await client.messages.create({
+    model: config.model,
+    max_tokens: options?.maxTokens ?? 256,
+    temperature: options?.temperature ?? 0.7,
+    system: systemPrompt,
+    messages: [{ role: "user", content: userPrompt }],
+  });
+
+  const textBlock = response.content.find((block) => block.type === "text");
+  if (!textBlock || textBlock.type !== "text") {
+    throw new Error("No text response from Claude");
+  }
+  return textBlock.text.trim();
+}
+
 export interface GeneratedPost {
   platform: string;
   variant: number;

--- a/src/lib/blob-storage.ts
+++ b/src/lib/blob-storage.ts
@@ -92,3 +92,42 @@ export async function deleteImage(url: string): Promise<void> {
 export function isBlobUrl(url: string): boolean {
   return url.includes(".public.blob.vercel-storage.com/");
 }
+
+/**
+ * Mirror an arbitrary remote image URL into Vercel Blob and return the new
+ * permanent Blob URL. Skips the round-trip if the URL is already on Blob,
+ * empty, or not http(s). Never throws — returns empty string on failure so
+ * the caller can fall back to writing the original URL (or nothing) without
+ * breaking the surrounding flow.
+ *
+ * Use this anywhere we'd otherwise persist a third-party-hosted image URL
+ * (Airtable signed URLs, Substack/CMS hero images, og:image scrapes) into
+ * a long-lived field — those URLs expire or get revoked.
+ */
+export async function mirrorRemoteImageToBlob(
+  remoteUrl: string | null | undefined,
+  prefix: "campaigns" | "posts" | "brands",
+  entityId: string,
+): Promise<string> {
+  if (!remoteUrl) return "";
+  if (isBlobUrl(remoteUrl)) return remoteUrl;
+  if (!/^https?:\/\//i.test(remoteUrl)) return "";
+  try {
+    const resp = await fetch(remoteUrl);
+    if (!resp.ok) {
+      console.warn(
+        `[mirror] ${prefix}/${entityId}: source fetch ${resp.status} for ${remoteUrl.slice(0, 120)}`,
+      );
+      return "";
+    }
+    const ct = resp.headers.get("content-type") ?? "image/jpeg";
+    const buf = Buffer.from(await resp.arrayBuffer());
+    return await uploadImage(prefix, entityId, buf, ct);
+  } catch (e) {
+    console.warn(
+      `[mirror] ${prefix}/${entityId}: failed for ${remoteUrl.slice(0, 120)}:`,
+      (e as Error).message,
+    );
+    return "";
+  }
+}

--- a/src/lib/brand-logo.ts
+++ b/src/lib/brand-logo.ts
@@ -1,0 +1,47 @@
+import type { Brand } from "@/lib/airtable/types";
+
+type LogoFields = Pick<
+  Brand,
+  | "logoColorSquare"
+  | "logoColorRect"
+  | "logoTransparentDark"
+  | "logoTransparentLight"
+  | "logoRectangularLight"
+  | "logoRectangularDark"
+  | "logoUrl"
+>;
+
+/**
+ * Pick the best available brand logo URL for the given surface.
+ *
+ * Priority:
+ *   1. The full-color variant for the requested shape (works on either bg).
+ *   2. The transparent variant suited to the surface (dark art on light bg,
+ *      light art on dark bg).
+ *   3. The opposite-surface transparent as a last resort.
+ *   4. The legacy `logoUrl` (Airtable attachment — may have expired).
+ */
+export function pickBrandLogo(
+  brand: LogoFields | null | undefined,
+  opts: { surface?: "light" | "dark"; shape?: "square" | "rect" } = {}
+): string | null {
+  if (!brand) return null;
+  const surface = opts.surface ?? "light";
+  const shape = opts.shape ?? "square";
+
+  const color = shape === "square" ? brand.logoColorSquare : brand.logoColorRect;
+
+  if (shape === "rect") {
+    const onSurface =
+      surface === "dark" ? brand.logoRectangularDark : brand.logoRectangularLight;
+    const opposite =
+      surface === "dark" ? brand.logoRectangularLight : brand.logoRectangularDark;
+    return color || onSurface || opposite || brand.logoUrl || null;
+  }
+
+  const onSurface =
+    surface === "dark" ? brand.logoTransparentLight : brand.logoTransparentDark;
+  const opposite =
+    surface === "dark" ? brand.logoTransparentDark : brand.logoTransparentLight;
+  return color || onSurface || opposite || brand.logoUrl || null;
+}

--- a/src/lib/pdf-carousel.ts
+++ b/src/lib/pdf-carousel.ts
@@ -1,5 +1,137 @@
 import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
 import type { MediaItem } from "@/lib/media-items";
+import { generateText, resolveAnthropicConfig } from "@/lib/anthropic";
+import type { Brand } from "@/lib/airtable/types";
+
+/**
+ * Maximum visible filename / documentTitle length before LinkedIn truncates
+ * the surface (Featured tile + feed card both clip near this bound). Leaves
+ * a few chars of breathing room.
+ */
+const TITLE_MAX = 55;
+
+/**
+ * Generate a LinkedIn document title — the headline that surfaces on the
+ * feed/Featured-tile attachment. Treats the surface as a magazine cover line:
+ * no brand name, no issue number, no category label, no duplication of the
+ * post body. AI-generated fresh per publish so titles stay tied to the
+ * current content.
+ *
+ * The same string powers `platforms.linkedin.documentTitle` (Zernio's wire
+ * field — primary signal LinkedIn surfaces) and the PDF filename (fallback,
+ * also visible if a reader downloads the file).
+ */
+export async function generateLinkedInDocumentTitle(args: {
+  campaignDescription: string | null | undefined;
+  editorialDirection: string | null | undefined;
+  postContent: string | null | undefined;
+  brand: Pick<Brand, "anthropicApiKeyLabel"> | null | undefined;
+}): Promise<string> {
+  const description = (args.campaignDescription || "").trim();
+  const direction = (args.editorialDirection || "").trim();
+  const postBody = (args.postContent || "").trim();
+
+  const fallback = description.split(/[.!?\n]/)[0].trim() || "Carousel";
+  const fallbackClipped = clipToMaxChars(fallback, TITLE_MAX) || "Carousel";
+
+  if (!description && !direction && !postBody) {
+    return fallbackClipped;
+  }
+
+  try {
+    const config = resolveAnthropicConfig(args.brand ?? undefined);
+    const system = `You write LinkedIn carousel cover titles — the headline that appears as the visible filename on the post tile.
+
+Rules:
+- 6 to 10 words, MUST be ≤${TITLE_MAX} characters total (including spaces).
+- Read like a magazine cover line: punchy, specific, makes a stranger want to click.
+- Title Case or sentence case — never ALL CAPS.
+- ASCII letters, digits, spaces, hyphens, colons, em-dashes, commas, question marks only. NO slashes, quotes, emojis, brackets.
+- NEVER include the brand name, issue/episode number, "Quick Post", "Newsletter", or any category label.
+- DO NOT paraphrase or duplicate the LinkedIn post body — the post is already visible separately. The title should complement, not repeat.
+- No period at the end. No surrounding quotes.
+
+Output ONLY the title text. No explanation, no preface, no quotes.`;
+
+    const userParts: string[] = [];
+    if (description) userParts.push(`Campaign topic:\n${description}`);
+    if (direction) userParts.push(`Editorial direction:\n${direction}`);
+    if (postBody) userParts.push(`Visible post body (DO NOT duplicate or paraphrase):\n${postBody}`);
+    userParts.push("Write ONE compelling title.");
+
+    const raw = await generateText(system, userParts.join("\n\n"), config, {
+      maxTokens: 60,
+      temperature: 0.8,
+    });
+
+    const cleaned = sanitizeTitle(raw);
+    if (cleaned && cleaned.length <= TITLE_MAX) return cleaned;
+    if (cleaned) return clipToMaxChars(cleaned, TITLE_MAX);
+    return fallbackClipped;
+  } catch (err) {
+    console.warn("[pdf-carousel] generateLinkedInDocumentTitle fell back:", err);
+    return fallbackClipped;
+  }
+}
+
+/**
+ * Convert a human-readable title to a filename-safe form, preserving case
+ * and word spacing. ASCII letters/digits/spaces/hyphens only, with `.pdf`.
+ */
+export function toPdfFilename(title: string): string {
+  const base =
+    sanitizeFilename(title).slice(0, TITLE_MAX).replace(/\s+$/, "").trim() ||
+    "Carousel";
+  return `${base}.pdf`;
+}
+
+/**
+ * Bundle: produce both the LinkedIn `documentTitle` (no extension) and the
+ * matching PDF filename. Use at every LinkedIn carousel publish/sync site.
+ */
+export async function prepareLinkedInPdfMetadata(args: {
+  campaignDescription: string | null | undefined;
+  editorialDirection: string | null | undefined;
+  postContent: string | null | undefined;
+  brand: Pick<Brand, "anthropicApiKeyLabel"> | null | undefined;
+}): Promise<{ documentTitle: string; filename: string }> {
+  const documentTitle = await generateLinkedInDocumentTitle(args);
+  return { documentTitle, filename: toPdfFilename(documentTitle) };
+}
+
+function sanitizeTitle(raw: string): string {
+  // Strip surrounding quotes, code fences, leading "Title:" prefixes, trailing periods.
+  let s = raw.trim();
+  s = s.replace(/^```[a-z]*\n?|```$/g, "").trim();
+  s = s.replace(/^["'“”‘’]+|["'“”‘’]+$/g, "").trim();
+  s = s.replace(/^(?:title|headline|tagline)\s*:\s*/i, "").trim();
+  s = s.replace(/\.+$/g, "").trim();
+  // Collapse internal whitespace.
+  s = s.replace(/\s+/g, " ");
+  // Drop disallowed chars while keeping common punctuation.
+  s = s.replace(/[\\\/"`~^*{}\[\]<>|=+@#$%]/g, "");
+  // Normalise smart quotes / em-dashes that survived.
+  s = s.replace(/[“”]/g, "").replace(/[‘’]/g, "'");
+  return s.trim();
+}
+
+function sanitizeFilename(title: string): string {
+  // Filename-friendly: drop punctuation that's hostile across filesystems &
+  // URLs, but keep spaces and case to stay human-readable.
+  return title
+    .replace(/[\\\/:"*?<>|]/g, "")
+    .replace(/[—–]/g, "-")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function clipToMaxChars(s: string, maxLen: number): string {
+  if (s.length <= maxLen) return s;
+  const cut = s.slice(0, maxLen);
+  const lastSpace = cut.lastIndexOf(" ");
+  if (lastSpace > maxLen * 0.5) return cut.slice(0, lastSpace).replace(/[,;:\-—]+$/, "").trim();
+  return cut.trim();
+}
 
 /**
  * Assemble multiple images into a PDF document for LinkedIn carousel posts.

--- a/src/lib/post-downstream-sync.ts
+++ b/src/lib/post-downstream-sync.ts
@@ -1,6 +1,7 @@
 import { getRecord, updateRecord } from "@/lib/airtable/client";
 import { createBrandClient } from "@/lib/late-api/client";
 import { parseMediaItems } from "@/lib/media-items";
+import { prepareLinkedInPdfMetadata } from "@/lib/pdf-carousel";
 
 export interface SyncResult {
   zernio: "skipped" | "ok" | "error";
@@ -26,6 +27,8 @@ interface PostFields {
 
 interface CampaignFieldsForSync {
   Name?: string;
+  Description?: string;
+  "Editorial Direction"?: string;
 }
 
 interface CampaignFields {
@@ -39,6 +42,7 @@ interface BrandFields {
   "Lnk.Bio Client ID Label": string;
   "Lnk.Bio Client Secret Label": string;
   Timezone: string;
+  "Anthropic API Key Label"?: string;
 }
 
 // Any route that writes post content/media/schedule fields is expected to call
@@ -63,7 +67,7 @@ export async function syncPostDownstream(postId: string): Promise<SyncResult> {
     const brand = await getRecord<BrandFields>("Brands", brandId);
 
     await Promise.allSettled([
-      syncZernio(postId, post.fields, brand.fields, campaign.fields.Name).then(
+      syncZernio(postId, post.fields, brand.fields, campaign.fields).then(
         (ok) => { result.zernio = ok ? "ok" : "skipped"; },
         (err) => {
           console.warn(`[post-sync] Zernio failed for ${postId}:`, err);
@@ -89,7 +93,7 @@ async function syncZernio(
   postId: string,
   post: PostFields,
   brand: BrandFields,
-  campaignName?: string
+  campaign: CampaignFieldsForSync
 ): Promise<boolean> {
   const zernioPostId = post["Zernio Post ID"];
   if (!zernioPostId) return false;
@@ -104,12 +108,19 @@ async function syncZernio(
   const userPdfUrl = post["Carousel PDF URL"];
   const updateBody: Record<string, unknown> = {};
   if (post.Content) updateBody.content = post.Content;
+  let linkedInDocumentTitle: string | undefined;
   if (platformLower === "linkedin" && userPdfUrl) {
     // User-supplied PDF override — single document item, image grid ignored.
     // Mirrors the publish-route logic at /api/posts/[id]/publish.
-    const filename = `${(campaignName || "Carousel").slice(0, 60)}.pdf`;
+    const meta = await prepareLinkedInPdfMetadata({
+      campaignDescription: campaign.Description,
+      editorialDirection: campaign["Editorial Direction"],
+      postContent: post.Content,
+      brand: { anthropicApiKeyLabel: brand["Anthropic API Key Label"] || null },
+    });
+    linkedInDocumentTitle = meta.documentTitle;
     updateBody.mediaItems = [
-      { type: "document" as const, url: userPdfUrl, filename },
+      { type: "document" as const, url: userPdfUrl, filename: meta.filename },
     ];
   } else {
     const mediaItems = parseMediaItems(post);
@@ -143,6 +154,10 @@ async function syncZernio(
     }
   } else if (platform === "facebook" || platform === "linkedin") {
     if (post["First Comment"]) psd.firstComment = post["First Comment"];
+  }
+
+  if (platform === "linkedin" && linkedInDocumentTitle) {
+    psd.documentTitle = linkedInDocumentTitle;
   }
 
   if (Object.keys(psd).length > 0) {


### PR DESCRIPTION
## Summary

Three logical workstreams that have built up on this branch — all verified locally. Closes [#81](https://github.com/JuergenB/polywiz-app/issues/81) (brand-selector portion) and [#201](https://github.com/JuergenB/polywiz-app/issues/201).

### 1. Cover generator polish (4 commits)
- [89b11af](https://github.com/JuergenB/polywiz-app/commit/89b11af) — dynamic N-stories carousel + brand subscribe URL + UI move
- [1ea7fb6](https://github.com/JuergenB/polywiz-app/commit/1ea7fb6), [e231af0](https://github.com/JuergenB/polywiz-app/commit/e231af0) — IG + LinkedIn inner-slide visual defaults locked in
- [469e6bb](https://github.com/JuergenB/polywiz-app/commit/469e6bb) — dynamic PDF slide count + shared numeral across inner slides

### 2. Image upload hygiene (2 commits)
- [7f5f13f](https://github.com/JuergenB/polywiz-app/commit/7f5f13f) — stop eager-deleting previous Blob on image upload (was racing with Airtable writes)
- [e1c15fb](https://github.com/JuergenB/polywiz-app/commit/e1c15fb) — mirror scraped campaign hero images to Vercel Blob (no more expiring source-site URLs)

### 3. Brand color logos + LinkedIn AI document titles (2 commits)
- [4796661](https://github.com/JuergenB/polywiz-app/commit/4796661) — full-color logo slot per shape + Blob-backed brand switcher dropdown. Adds 6-slot LogoManager (Color · On Light · On Dark × Square + Rectangular) and the `pickBrandLogo` helper. Brand switcher no longer flashes broken Airtable attachment URLs.
- [eea907f](https://github.com/JuergenB/polywiz-app/commit/eea907f) — AI-generated LinkedIn carousel headline (≤55 chars, no brand/issue#/category boilerplate) used for both `platforms.linkedin.documentTitle` (Zernio wire field, primary surface) and the PDF filename. Replaces slugified `quick-post-the-intersect-art-in-tech-and-tech-in-art-…pdf` with `Why the Hardest Path Has Become the Most Honest.pdf`-style headlines.

## Test plan

- [ ] Brand settings → brands page renders the 2×3 LogoManager grid; existing The Intersect transparents fall into the right slots; uploading to a Color square slot persists to Vercel Blob and shows up in the brand switcher trigger
- [ ] Brand switcher dropdown shows all four brands with non-stale logos (Color square if uploaded, otherwise transparent fallback)
- [ ] `Create Campaign` page shows white-on-dark logo in the dark zinc-900 brand header
- [ ] Inner-slides cover generator: render N-stories carousel for IG and LinkedIn — verify defaults match approved spec
- [ ] LinkedIn carousel publish (next organic) — observe `documentTitle` renders on the post tile (tracked separately in [#202](https://github.com/JuergenB/polywiz-app/issues/202))
- [ ] Airtable scraped hero images are mirrored to Blob on campaign generation

## Follow-ups (not blocking this PR)

- [#200](https://github.com/JuergenB/polywiz-app/issues/200) — upgrade `@getlatedev/node` 0.1.7 → 0.2.100 (drops the `documentTitle` smuggle cast). Will be its own PR off this merged main.
- [#202](https://github.com/JuergenB/polywiz-app/issues/202) — verify documentTitle in prod, remove dev console.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)