### PR TITLE
feat(scheduling): redistribute campaign across new window — backend + UI (#178 Phases 1+2)

### DIFF
--- a/src/app/api/campaigns/[id]/redistribute/route.ts
+++ b/src/app/api/campaigns/[id]/redistribute/route.ts
@@ -30,6 +30,13 @@ import { schedulePostsAlgorithm, type ScheduleSlot } from "@/lib/scheduling";
 import { applyPostChanges } from "@/lib/post-apply";
 import type { DistributionBias, PlatformCadenceConfig } from "@/lib/airtable/types";
 
+// Vercel: 60s max on Pro for serverless functions. Apply mode runs through
+// a per-API-throttled chain (see src/lib/api-throttle.ts), so wall-clock
+// scales with number of posts. For ~20 posts that's ~50s; for 25+ this
+// will time out and Phase 3 (downstream sync) should be moved to SSE
+// streaming. Tracked as a follow-up.
+export const maxDuration = 60;
+
 const PLATFORM_MAP: Record<string, string> = {
   Instagram: "instagram",
   "X/Twitter": "twitter",
@@ -289,6 +296,7 @@ export async function POST(
     }
 
     // ── Apply mode ───────────────────────────────────────────────────────
+    const applyStartMs = Date.now();
     // Strategy (per spec's proposed default for partial-failure UX):
     // 1. Update all Airtable post dates first (atomic enough — Airtable does
     //    not give us a transaction, but per-record updates are independent).
@@ -374,6 +382,7 @@ export async function POST(
       downstreamOk: results.filter((r) => r.downstream === "ok").length,
       downstreamSkipped: results.filter((r) => r.downstream === "skipped").length,
       failures: results.filter((r) => r.airtable === "error" || r.downstream === "error").length,
+      wallClockMs: Date.now() - applyStartMs,
     };
 
     console.log(`[redistribute] Campaign ${campaignId} applied:`, summary);

--- a/src/app/api/campaigns/[id]/redistribute/route.ts
+++ b/src/app/api/campaigns/[id]/redistribute/route.ts
@@ -198,6 +198,21 @@ export async function POST(
       return inSameBrand && !inThisCampaign && occupiesSlot && !!p.fields["Scheduled Date"];
     });
 
+    // Count externals that actually fall WITHIN the redistribute window — these
+    // are the ones that will affect placement. Out-of-window externals are
+    // silently dropped by the scheduler's per-day lookup; counting them in the
+    // displayed stat would overstate collision pressure.
+    const windowStartMs = startDate.getTime();
+    const windowEndMs = new Date(startDate.getTime() + durationDays * 86_400_000).getTime();
+    const inWindowExternalCount = externalPosts.reduce((acc, p) => {
+      const t = new Date(p.fields["Scheduled Date"]!).getTime();
+      return t >= windowStartMs && t < windowEndMs ? acc + 1 : acc;
+    }, 0);
+    const inWindowReservationCount = thisCampaignReservations.reduce((acc, p) => {
+      const t = new Date(p.fields["Scheduled Date"]!).getTime();
+      return t >= windowStartMs && t < windowEndMs ? acc + 1 : acc;
+    }, 0);
+
     // Build excludedDates: per platform, count of slots taken per day key
     // (UTC component, to match what schedulePostsAlgorithm reads).
     const excludedDates = new Map<string, Map<string, number>>();
@@ -260,8 +275,15 @@ export async function POST(
         durationDays,
         distributionBias,
         participantCount: participants.length,
-        externalCollisionCount: externalPosts.length,
-        reservationCount: thisCampaignReservations.length,
+        // In-window collision counts are what the scheduler actually consults
+        // and what affects placement. The full brand-wide totals are returned
+        // separately for diagnostics.
+        externalCollisionCount: inWindowExternalCount,
+        reservationCount: inWindowReservationCount,
+        diagnostics: {
+          totalBrandWideExternalCount: externalPosts.length,
+          totalReservationCount: thisCampaignReservations.length,
+        },
         mapping,
       });
     }

--- a/src/app/api/campaigns/[id]/redistribute/route.ts
+++ b/src/app/api/campaigns/[id]/redistribute/route.ts
@@ -1,0 +1,376 @@
+/**
+ * POST /api/campaigns/[id]/redistribute
+ *
+ * Phase D of the scheduling-trust epic ([#178](https://github.com/JuergenB/polywiz-app/issues/178)).
+ *
+ * Re-spreads a campaign's surviving posts across a new date window using the
+ * existing scheduler. Treats brand-wide other-campaign posts as collision
+ * constraints (not as additive contributions to this campaign's curve).
+ *
+ * Modes:
+ *   - `apply: false` (default) — preview. Returns the proposed mapping
+ *     `{ postId, oldDate, newDate, platform }[]` without writing.
+ *   - `apply: true` — commits Airtable updates, then fires Zernio + lnk.bio
+ *     sync per Scheduled post. Approved posts only get an Airtable date
+ *     update (no downstream until the campaign is scheduled).
+ *
+ * Participation:
+ *   - Re-placed: Approved + Scheduled (both get new dates).
+ *   - Reservations (collision-only): Pending posts with a Scheduled Date.
+ *   - Excluded: Published (dates spent), Dismissed (irrelevant).
+ *
+ * Cross-campaign collisions: every Scheduled/Published post for the same
+ * brand on other campaigns becomes part of `excludedDates`.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getRecord, listRecords, updateRecord } from "@/lib/airtable/client";
+import { getUserBrandAccess, hasCampaignAccess } from "@/lib/brand-access";
+import { schedulePostsAlgorithm, type ScheduleSlot } from "@/lib/scheduling";
+import { applyPostChanges } from "@/lib/post-apply";
+import type { DistributionBias, PlatformCadenceConfig } from "@/lib/airtable/types";
+
+const PLATFORM_MAP: Record<string, string> = {
+  Instagram: "instagram",
+  "X/Twitter": "twitter",
+  LinkedIn: "linkedin",
+  Facebook: "facebook",
+  Threads: "threads",
+  Bluesky: "bluesky",
+  Pinterest: "pinterest",
+  TikTok: "tiktok",
+  YouTube: "youtube",
+  Reddit: "reddit",
+};
+
+interface CampaignFields {
+  Name: string;
+  Brand: string[];
+  "Duration Days": number;
+  "Distribution Bias": string;
+  "Start Date"?: string;
+  "Platform Cadence"?: string;
+}
+
+interface PostFields {
+  Campaign: string[];
+  Platform: string;
+  Status: string;
+  "Scheduled Date"?: string;
+  "Sort Order"?: number | null;
+  "Zernio Post ID"?: string;
+}
+
+interface RedistributeBody {
+  startDate?: unknown;
+  endDate?: unknown;
+  distributionBias?: unknown;
+  apply?: unknown;
+}
+
+interface MappingEntry {
+  postId: string;
+  platform: string;
+  oldDate: string | null;
+  newDate: string;
+  status: string;
+}
+
+const VALID_BIASES: DistributionBias[] = ["Front-loaded", "Balanced", "Back-loaded"];
+
+function isYmd(s: unknown): s is string {
+  return typeof s === "string" && /^\d{4}-\d{2}-\d{2}$/.test(s);
+}
+
+function diffDaysInclusive(start: Date, end: Date): number {
+  const s = Date.UTC(start.getFullYear(), start.getMonth(), start.getDate());
+  const e = Date.UTC(end.getFullYear(), end.getMonth(), end.getDate());
+  return Math.round((e - s) / 86_400_000) + 1;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id: campaignId } = await params;
+    const body = (await request.json().catch(() => ({}))) as RedistributeBody;
+
+    // ── Validate body ────────────────────────────────────────────────────
+    if (!isYmd(body.startDate) || !isYmd(body.endDate)) {
+      return NextResponse.json(
+        { error: "startDate and endDate must be YYYY-MM-DD strings" },
+        { status: 400 },
+      );
+    }
+    if (typeof body.distributionBias !== "string" ||
+        !VALID_BIASES.includes(body.distributionBias as DistributionBias)) {
+      return NextResponse.json(
+        { error: `distributionBias must be one of ${VALID_BIASES.join(", ")}` },
+        { status: 400 },
+      );
+    }
+    const apply = body.apply === true;
+    const distributionBias = body.distributionBias as DistributionBias;
+
+    const startDate = new Date(body.startDate + "T00:00:00");
+    const endDate = new Date(body.endDate + "T00:00:00");
+    if (endDate <= startDate) {
+      return NextResponse.json({ error: "endDate must be after startDate" }, { status: 400 });
+    }
+    const durationDays = diffDaysInclusive(startDate, endDate);
+
+    // ── Auth + campaign ──────────────────────────────────────────────────
+    const access = await getUserBrandAccess();
+    const campaign = await getRecord<CampaignFields>("Campaigns", campaignId);
+    if (access && !hasCampaignAccess(access, campaign.fields.Brand || [])) {
+      return NextResponse.json(
+        { error: "You do not have access to this campaign" },
+        { status: 403 },
+      );
+    }
+    const brandId = campaign.fields.Brand?.[0];
+    if (!brandId) {
+      return NextResponse.json({ error: "Campaign has no brand assigned" }, { status: 400 });
+    }
+
+    // ── Resolve cadence (campaign override → brand → globals) ────────────
+    let cadence: PlatformCadenceConfig | null = null;
+    if (campaign.fields["Platform Cadence"]) {
+      try {
+        cadence = JSON.parse(campaign.fields["Platform Cadence"]) as PlatformCadenceConfig;
+      } catch { /* fall through */ }
+    }
+    if (!cadence) {
+      try {
+        const brand = await getRecord<{ "Platform Cadence"?: string }>("Brands", brandId);
+        if (brand.fields["Platform Cadence"]) {
+          cadence = JSON.parse(brand.fields["Platform Cadence"]) as PlatformCadenceConfig;
+        }
+      } catch { /* fall through */ }
+    }
+
+    // ── Fetch all posts; partition into participants / reservations / externals ─
+    // The Airtable filter API can't easily express "linked record contains X",
+    // so we paginate everything and filter in memory. Same pattern as
+    // simulate-campaign-schedule.mts.
+    const allPosts = await listRecords<PostFields>("Posts", {});
+
+    const thisCampaignPosts = allPosts.filter(
+      (p) => p.fields.Campaign?.includes(campaignId),
+    );
+
+    // Participants: re-placed in this run.
+    const participants = thisCampaignPosts.filter(
+      (p) => p.fields.Status === "Approved" || p.fields.Status === "Scheduled",
+    );
+    if (participants.length === 0) {
+      return NextResponse.json(
+        { error: "No Approved or Scheduled posts to redistribute" },
+        { status: 400 },
+      );
+    }
+
+    // Reservations: this campaign's Pending posts that have a Scheduled Date —
+    // they hold their slot, contribute to collision-avoidance counts.
+    const thisCampaignReservations = thisCampaignPosts.filter(
+      (p) => p.fields.Status === "Pending" && p.fields["Scheduled Date"],
+    );
+
+    // Externals: brand-wide other-campaign Scheduled+Published posts.
+    // Determine "this brand" by reading every campaign in the brand and
+    // collecting their post IDs. Cheaper alternative: trust that posts'
+    // Brand link (if any) matches campaign brand — but Posts table doesn't
+    // carry a direct Brand field, so we go through Campaigns.
+    const allCampaigns = await listRecords<{ Brand?: string[] }>("Campaigns", {});
+    const sameBrandCampaignIds = new Set(
+      allCampaigns
+        .filter((c) => c.fields.Brand?.includes(brandId))
+        .map((c) => c.id),
+    );
+    const externalPosts = allPosts.filter((p) => {
+      const cIds = p.fields.Campaign || [];
+      // Same brand, NOT this campaign, status takes a slot.
+      const inSameBrand = cIds.some((id) => sameBrandCampaignIds.has(id));
+      const inThisCampaign = cIds.includes(campaignId);
+      const occupiesSlot =
+        p.fields.Status === "Scheduled" || p.fields.Status === "Published";
+      return inSameBrand && !inThisCampaign && occupiesSlot && !!p.fields["Scheduled Date"];
+    });
+
+    // Build excludedDates: per platform, count of slots taken per day key
+    // (UTC component, to match what schedulePostsAlgorithm reads).
+    const excludedDates = new Map<string, Map<string, number>>();
+    const recordSlot = (platformAirtable: string, isoDate: string) => {
+      const platform =
+        PLATFORM_MAP[platformAirtable] || platformAirtable.toLowerCase();
+      const dateStr = isoDate.split("T")[0];
+      let perPlatform = excludedDates.get(platform);
+      if (!perPlatform) {
+        perPlatform = new Map<string, number>();
+        excludedDates.set(platform, perPlatform);
+      }
+      perPlatform.set(dateStr, (perPlatform.get(dateStr) ?? 0) + 1);
+    };
+    for (const p of externalPosts) {
+      recordSlot(p.fields.Platform, p.fields["Scheduled Date"]!);
+    }
+    for (const p of thisCampaignReservations) {
+      recordSlot(p.fields.Platform, p.fields["Scheduled Date"]!);
+    }
+
+    // ── Run scheduler ────────────────────────────────────────────────────
+    const algoPosts = participants.map((p) => ({
+      id: p.id,
+      platform: PLATFORM_MAP[p.fields.Platform] || p.fields.Platform.toLowerCase(),
+      sortOrder: p.fields["Sort Order"] ?? null,
+    }));
+
+    const slots: ScheduleSlot[] = schedulePostsAlgorithm({
+      posts: algoPosts,
+      startDate,
+      durationDays,
+      bias: distributionBias,
+      cadence,
+      excludedDates,
+      additiveMode: false,
+    });
+
+    const slotByPostId = new Map<string, ScheduleSlot>();
+    for (const s of slots) slotByPostId.set(s.postId, s);
+
+    const mapping: MappingEntry[] = participants.map((p) => {
+      const slot = slotByPostId.get(p.id);
+      return {
+        postId: p.id,
+        platform: PLATFORM_MAP[p.fields.Platform] || p.fields.Platform.toLowerCase(),
+        oldDate: p.fields["Scheduled Date"] ?? null,
+        newDate: slot?.scheduledDate ?? "",
+        status: p.fields.Status,
+      };
+    });
+
+    // ── Preview mode: return without writing ─────────────────────────────
+    if (!apply) {
+      return NextResponse.json({
+        preview: true,
+        campaignId,
+        startDate: body.startDate,
+        endDate: body.endDate,
+        durationDays,
+        distributionBias,
+        participantCount: participants.length,
+        externalCollisionCount: externalPosts.length,
+        reservationCount: thisCampaignReservations.length,
+        mapping,
+      });
+    }
+
+    // ── Apply mode ───────────────────────────────────────────────────────
+    // Strategy (per spec's proposed default for partial-failure UX):
+    // 1. Update all Airtable post dates first (atomic enough — Airtable does
+    //    not give us a transaction, but per-record updates are independent).
+    // 2. Update campaign Start Date / Duration Days / Distribution Bias.
+    // 3. For each Scheduled post (has Zernio Post ID), call applyPostChanges
+    //    to sync the new scheduledFor to Zernio + re-sync lnk.bio. Approved
+    //    posts have no Zernio post yet, so just the Airtable date update.
+    // 4. Collect per-post results; return summary so the UI can surface
+    //    partial failures and offer retry.
+
+    const results: Array<{
+      postId: string;
+      platform: string;
+      airtable: "ok" | "error";
+      downstream: "ok" | "skipped" | "error";
+      error?: string;
+    }> = [];
+
+    for (const m of mapping) {
+      if (!m.newDate) {
+        results.push({
+          postId: m.postId,
+          platform: m.platform,
+          airtable: "error",
+          downstream: "skipped",
+          error: "Scheduler returned no slot",
+        });
+        continue;
+      }
+      try {
+        await updateRecord("Posts", m.postId, { "Scheduled Date": m.newDate });
+        results.push({
+          postId: m.postId,
+          platform: m.platform,
+          airtable: "ok",
+          downstream: "skipped",
+        });
+      } catch (err) {
+        results.push({
+          postId: m.postId,
+          platform: m.platform,
+          airtable: "error",
+          downstream: "skipped",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    // Update campaign window
+    try {
+      await updateRecord("Campaigns", campaignId, {
+        "Start Date": body.startDate,
+        "Duration Days": durationDays,
+        "Distribution Bias": distributionBias,
+      });
+    } catch (err) {
+      console.error(`[redistribute] Failed to update campaign window for ${campaignId}:`, err);
+    }
+
+    // Downstream sync: Scheduled posts get Zernio updatePost + lnk.bio re-sync.
+    // Sequential rather than parallel so we don't blast Zernio's rate limit.
+    for (const m of mapping) {
+      const result = results.find((r) => r.postId === m.postId);
+      if (!result || result.airtable !== "ok") continue;
+      if (m.status !== "Scheduled") continue;
+      try {
+        const sync = await applyPostChanges(m.postId);
+        if (sync.zernio === "ok" || sync.zernio === "skipped") {
+          result.downstream = sync.lnkBio === "error" ? "error" : "ok";
+        } else {
+          result.downstream = "error";
+        }
+        if (sync.error) result.error = sync.error;
+      } catch (err) {
+        result.downstream = "error";
+        result.error = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    const summary = {
+      total: results.length,
+      airtableOk: results.filter((r) => r.airtable === "ok").length,
+      downstreamOk: results.filter((r) => r.downstream === "ok").length,
+      downstreamSkipped: results.filter((r) => r.downstream === "skipped").length,
+      failures: results.filter((r) => r.airtable === "error" || r.downstream === "error").length,
+    };
+
+    console.log(`[redistribute] Campaign ${campaignId} applied:`, summary);
+
+    return NextResponse.json({
+      applied: true,
+      campaignId,
+      startDate: body.startDate,
+      endDate: body.endDate,
+      durationDays,
+      distributionBias,
+      summary,
+      results,
+    });
+  } catch (error) {
+    console.error("[redistribute] Failed:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to redistribute" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/campaigns/[id]/schedule/route.ts
+++ b/src/app/api/campaigns/[id]/schedule/route.ts
@@ -182,7 +182,10 @@ export async function POST(
       sortOrder: p.fields["Sort Order"] ?? null,
     }));
 
-    // Generate the schedule
+    // Generate the schedule. `additiveMode: true` because the existing posts
+    // counted in `alreadyScheduledDates` are from THIS campaign — they
+    // contribute to the curve's target distribution, and Phase B's deficit-
+    // fill should activate to keep combined existing+new on-curve.
     const slots = schedulePostsAlgorithm({
       posts,
       startDate,
@@ -190,6 +193,7 @@ export async function POST(
       bias,
       cadence,
       excludedDates: alreadyScheduledDates,
+      additiveMode: true,
     });
 
     if (isPreview) {

--- a/src/app/dashboard/campaigns/[id]/page.tsx
+++ b/src/app/dashboard/campaigns/[id]/page.tsx
@@ -86,6 +86,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ArchiveCampaignDialog } from "@/components/campaigns/archive-campaign-dialog";
+import { RedistributeDialog } from "@/components/campaigns/redistribute-dialog";
 import { countPostsByBucket } from "@/components/campaigns/campaign-row-actions";
 import {
   ArrowLeft,
@@ -110,6 +111,7 @@ import {
   ChevronUp,
   Archive,
   ArchiveRestore,
+  CalendarRange,
   Eraser,
   MoreHorizontal,
   Save,
@@ -3086,10 +3088,12 @@ function CampaignHeaderActions({
   const queryClient = useQueryClient();
   const router = useRouter();
   const [archiveOpen, setArchiveOpen] = useState(false);
+  const [redistributeOpen, setRedistributeOpen] = useState(false);
   const [busy, setBusy] = useState<"unarchive" | "cleanup" | null>(null);
 
   const isArchived = Boolean(campaign.archivedAt);
   const counts = countPostsByBucket(posts);
+  const canRedistribute = !isArchived && (counts.approved + counts.scheduled) > 0;
 
   async function handleUnarchive() {
     setBusy("unarchive");
@@ -3145,6 +3149,17 @@ function CampaignHeaderActions({
             </DropdownMenuItem>
           ) : (
             <>
+              <DropdownMenuItem
+                onClick={() => setRedistributeOpen(true)}
+                disabled={!canRedistribute}
+              >
+                <CalendarRange className="h-4 w-4 mr-2" /> Redistribute…
+                {canRedistribute && (
+                  <span className="ml-auto text-xs text-muted-foreground">
+                    {counts.approved + counts.scheduled}
+                  </span>
+                )}
+              </DropdownMenuItem>
               <DropdownMenuItem onClick={handleCleanup} disabled={counts.pending === 0}>
                 <Eraser className="h-4 w-4 mr-2" /> Clean up drafts
                 {counts.pending > 0 && (
@@ -3177,6 +3192,13 @@ function CampaignHeaderActions({
         open={archiveOpen}
         onOpenChange={setArchiveOpen}
         onArchived={() => router.push("/dashboard/campaigns")}
+      />
+
+      <RedistributeDialog
+        campaign={campaign}
+        posts={posts}
+        open={redistributeOpen}
+        onOpenChange={setRedistributeOpen}
       />
     </>
   );

--- a/src/components/campaigns/campaign-timeline.tsx
+++ b/src/components/campaigns/campaign-timeline.tsx
@@ -65,13 +65,35 @@ export function CampaignTimeline({
     [posts]
   );
 
-  // Group posts by day with platform info
-  const { daySlots, activePlatforms, monthMarkers } = useMemo(() => {
-    const endDate = addDays(campaignStartDate, durationDays);
-    const platforms = new Set<string>();
-    const today = new Date();
+  // The visible timeline range encompasses the WHOLE campaign story:
+  // - left edge = earliest of (campaign Start Date, earliest scheduled/published post)
+  // - right edge = latest of (campaign Start + durationDays, latest scheduled post)
+  // The campaign's planned window (Start → Start+durationDays) lives inside
+  // this range. "Today" floats as a vertical marker wherever today actually
+  // is — it's no longer conflated with the start.
+  const { daySlots, activePlatforms, monthMarkers, effectiveStart, effectiveDays } = useMemo(() => {
+    const plannedEnd = addDays(campaignStartDate, durationDays);
+    const todayDate = new Date();
 
-    // Build day slots
+    // Find earliest/latest post anchors (use day-floor so we render whole days)
+    const postTimes = scheduledPosts
+      .map((p) => new Date(p.scheduledDate).getTime())
+      .filter((t) => Number.isFinite(t));
+    const earliestPost = postTimes.length > 0
+      ? new Date(Math.min(...postTimes))
+      : campaignStartDate;
+    const latestPost = postTimes.length > 0
+      ? new Date(Math.max(...postTimes))
+      : plannedEnd;
+
+    const dayFloor = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+    const startCandidate = earliestPost.getTime() < campaignStartDate.getTime()
+      ? dayFloor(earliestPost) : dayFloor(campaignStartDate);
+    const endCandidate = latestPost.getTime() > plannedEnd.getTime()
+      ? dayFloor(latestPost) : dayFloor(plannedEnd);
+    const span = Math.max(1, differenceInDays(endCandidate, startCandidate));
+
+    const platforms = new Set<string>();
     const slots: Array<{
       dayOffset: number;
       date: Date;
@@ -80,8 +102,8 @@ export function CampaignTimeline({
       isToday: boolean;
     }> = [];
 
-    for (let d = 0; d <= durationDays; d++) {
-      const date = addDays(campaignStartDate, d);
+    for (let d = 0; d <= span; d++) {
+      const date = addDays(startCandidate, d);
       const dateStr = format(date, "yyyy-MM-dd");
       const dayPosts = scheduledPosts.filter(
         (p) => p.scheduledDate.split("T")[0] === dateStr
@@ -98,34 +120,45 @@ export function CampaignTimeline({
           date,
           posts: dayPosts,
           platforms: platMap,
-          isToday: isSameDay(date, today),
+          isToday: isSameDay(date, todayDate),
         });
       }
     }
 
-    // Month markers along the timeline
     const months: Array<{ label: string; position: number }> = [];
     let lastMonth = -1;
-    for (let d = 0; d <= durationDays; d++) {
-      const date = addDays(campaignStartDate, d);
+    for (let d = 0; d <= span; d++) {
+      const date = addDays(startCandidate, d);
       const month = date.getMonth();
       if (month !== lastMonth) {
         months.push({
           label: d === 0 ? format(date, "MMM d") : format(date, "MMM"),
-          position: durationDays > 0 ? d / durationDays : 0,
+          position: span > 0 ? d / span : 0,
         });
         lastMonth = month;
       }
     }
 
-    return { daySlots: slots, activePlatforms: [...platforms], monthMarkers: months };
+    return {
+      daySlots: slots,
+      activePlatforms: [...platforms],
+      monthMarkers: months,
+      effectiveStart: startCandidate,
+      effectiveDays: span,
+    };
   }, [scheduledPosts, campaignStartDate, durationDays]);
 
   if (scheduledPosts.length === 0) return null;
 
+  // Each day occupies a slot of width 1/(effectiveDays+1). Dots and the
+  // today marker are positioned at the MIDPOINT of their day's slot so
+  // they don't clip the card edges at days 0 or N.
+  const slotCount = effectiveDays + 1;
   const today = new Date();
-  const todayOffset = differenceInDays(today, campaignStartDate);
-  const todayPosition = durationDays > 0 ? Math.max(0, Math.min(1, todayOffset / durationDays)) : 0;
+  const todayOffset = differenceInDays(today, effectiveStart);
+  const todayPosition = slotCount > 0
+    ? Math.max(0, Math.min(1, (todayOffset + 0.5) / slotCount))
+    : 0;
 
   return (
     <TooltipProvider delayDuration={150}>
@@ -184,7 +217,7 @@ export function CampaignTimeline({
             <span
               className="absolute right-0 text-[10px] text-muted-foreground"
             >
-              {format(addDays(campaignStartDate, durationDays), "MMM d")}
+              {format(addDays(effectiveStart, effectiveDays), "MMM d")}
             </span>
           </div>
 
@@ -202,16 +235,17 @@ export function CampaignTimeline({
           {/* Track with posts */}
           <div className="relative h-10 bg-muted/30 rounded-md border border-border/50">
             {/* Today marker */}
-            {todayOffset >= 0 && todayOffset <= durationDays && (
+            {todayOffset >= 0 && todayOffset <= effectiveDays && (
               <div
                 className="absolute top-0 bottom-0 w-px bg-primary/50 z-10"
                 style={{ left: `${todayPosition * 100}%` }}
               />
             )}
 
-            {/* Post markers — uniform 8px dots, side-by-side */}
+            {/* Post markers — uniform 8px dots, side-by-side, centered in
+                the day's slot so they don't clip the card edges. */}
             {daySlots.map((slot, i) => {
-              const position = durationDays > 0 ? slot.dayOffset / durationDays : 0;
+              const position = slotCount > 0 ? (slot.dayOffset + 0.5) / slotCount : 0;
               const platformEntries = [...slot.platforms.entries()];
 
               return (
@@ -253,7 +287,7 @@ export function CampaignTimeline({
           </div>
 
           {/* Today label below the track */}
-          {todayOffset >= 0 && todayOffset <= durationDays && (
+          {todayOffset >= 0 && todayOffset <= effectiveDays && (
             <div className="relative h-4">
               <span
                 className="absolute text-[9px] text-primary font-medium"

--- a/src/components/campaigns/redistribute-dialog.tsx
+++ b/src/components/campaigns/redistribute-dialog.tsx
@@ -190,14 +190,17 @@ export function RedistributeDialog({ campaign, posts, open, onOpenChange }: Prop
           `Redistributed ${summary.airtableOk}/${summary.total} (${summary.failures} downstream failure${summary.failures === 1 ? "" : "s"} — refresh and retry)`,
         );
       }
-      await queryClient.invalidateQueries({ queryKey: ["campaign", campaign.id] });
-      await queryClient.invalidateQueries({ queryKey: ["campaigns"] });
-      onOpenChange(false);
+      // Per memory rule (feedback_reload_over_invalidation): overlay-mutating
+      // Airtable actions need a hard page reload, not just queryClient
+      // invalidate — we've hit stale-state bugs in this codebase before.
+      // Brief delay so the toast registers before the reload swaps the page.
+      setTimeout(() => window.location.reload(), 800);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Redistribute failed");
-    } finally {
       setApplying(false);
     }
+    // Note: no finally block clearing applying — on success we're about to
+    // reload, so we keep the spinner visible during the 800ms toast window.
   }
 
   // Build synthetic Post[] from preview mapping for the proposed timeline.
@@ -339,6 +342,18 @@ export function RedistributeDialog({ campaign, posts, open, onOpenChange }: Prop
             </div>
           )}
         </div>
+
+        {applying && preview && (
+          <div className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2.5 text-xs text-blue-900 dark:border-blue-900/50 dark:bg-blue-950/30 dark:text-blue-200">
+            <div className="flex items-center gap-2 font-medium">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Applying to {preview.mapping.length} post{preview.mapping.length === 1 ? "" : "s"}…
+            </div>
+            <div className="mt-1 ml-5.5 leading-relaxed">
+              Updating Airtable, then syncing each scheduled post to Zernio + lnk.bio. Throttled to stay under API rate limits — expect ~{Math.max(15, Math.ceil(preview.mapping.length * 1.5))}s. The page will refresh automatically when done.
+            </div>
+          </div>
+        )}
 
         <DialogFooter className="gap-2 sm:gap-2">
           <Button

--- a/src/components/campaigns/redistribute-dialog.tsx
+++ b/src/components/campaigns/redistribute-dialog.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { toast } from "sonner";
+import { CalendarRange, Loader2 } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import { CampaignTimeline } from "./campaign-timeline";
+import type { Campaign, Post, PostStatus, DistributionBias } from "@/lib/airtable/types";
+
+interface MappingEntry {
+  postId: string;
+  platform: string;
+  oldDate: string | null;
+  newDate: string;
+  status: string;
+}
+
+interface PreviewResponse {
+  preview: true;
+  campaignId: string;
+  startDate: string;
+  endDate: string;
+  durationDays: number;
+  distributionBias: DistributionBias;
+  participantCount: number;
+  externalCollisionCount: number;
+  reservationCount: number;
+  mapping: MappingEntry[];
+}
+
+interface ApplyResponse {
+  applied: true;
+  summary: {
+    total: number;
+    airtableOk: number;
+    downstreamOk: number;
+    downstreamSkipped: number;
+    failures: number;
+  };
+  results: Array<{
+    postId: string;
+    platform: string;
+    airtable: "ok" | "error";
+    downstream: "ok" | "skipped" | "error";
+    error?: string;
+  }>;
+}
+
+interface Props {
+  campaign: Campaign;
+  posts: Post[]; // existing campaign posts (for the "current" timeline)
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const BIAS_OPTIONS: Array<{ value: DistributionBias; label: string; description: string }> = [
+  { value: "Front-loaded", label: "Front-loaded", description: "Heavy at the start, tapering" },
+  { value: "Balanced", label: "Balanced", description: "Even distribution" },
+  { value: "Back-loaded", label: "Back-loaded", description: "Light at the start, building" },
+];
+
+function ymd(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  return format(d, "yyyy-MM-dd");
+}
+
+function addDays(date: Date, n: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + n);
+  return d;
+}
+
+export function RedistributeDialog({ campaign, posts, open, onOpenChange }: Props) {
+  const queryClient = useQueryClient();
+
+  // Default new window: today → today + current durationDays. User adjusts.
+  const today = useMemo(() => {
+    const t = new Date();
+    t.setHours(0, 0, 0, 0);
+    return t;
+  }, []);
+  const [startDate, setStartDate] = useState<string>(ymd(today));
+  const [endDate, setEndDate] = useState<string>(
+    ymd(addDays(today, Math.max(1, campaign.durationDays - 1))),
+  );
+  const [bias, setBias] = useState<DistributionBias>(
+    (campaign.distributionBias as DistributionBias) || "Front-loaded",
+  );
+
+  const [preview, setPreview] = useState<PreviewResponse | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [applying, setApplying] = useState(false);
+
+  // Reset preview when inputs change — forces user to re-preview before applying.
+  useEffect(() => {
+    setPreview(null);
+    setPreviewError(null);
+  }, [startDate, endDate, bias]);
+
+  // Reset everything when the dialog closes.
+  useEffect(() => {
+    if (!open) {
+      setPreview(null);
+      setPreviewError(null);
+      setPreviewing(false);
+      setApplying(false);
+    }
+  }, [open]);
+
+  const participantCount = posts.filter(
+    (p) => p.status === "Approved" || p.status === "Scheduled",
+  ).length;
+
+  async function handlePreview() {
+    setPreviewing(true);
+    setPreview(null);
+    setPreviewError(null);
+    try {
+      const res = await fetch(`/api/campaigns/${campaign.id}/redistribute`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          startDate,
+          endDate,
+          distributionBias: bias,
+          apply: false,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setPreviewError(data?.error || "Preview failed");
+        return;
+      }
+      setPreview(data as PreviewResponse);
+    } catch (err) {
+      setPreviewError(err instanceof Error ? err.message : "Preview failed");
+    } finally {
+      setPreviewing(false);
+    }
+  }
+
+  async function handleApply() {
+    if (!preview) return;
+    setApplying(true);
+    try {
+      const res = await fetch(`/api/campaigns/${campaign.id}/redistribute`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          startDate,
+          endDate,
+          distributionBias: bias,
+          apply: true,
+        }),
+      });
+      const data = (await res.json()) as ApplyResponse | { error?: string };
+      if (!res.ok || !("summary" in data)) {
+        toast.error(("error" in data && data.error) || "Redistribute failed");
+        return;
+      }
+      const { summary } = data as ApplyResponse;
+      if (summary.failures === 0) {
+        toast.success(
+          `Redistributed ${summary.total} post${summary.total === 1 ? "" : "s"} — ${summary.downstreamOk} synced downstream`,
+        );
+      } else {
+        toast.warning(
+          `Redistributed ${summary.airtableOk}/${summary.total} (${summary.failures} downstream failure${summary.failures === 1 ? "" : "s"} — refresh and retry)`,
+        );
+      }
+      await queryClient.invalidateQueries({ queryKey: ["campaign", campaign.id] });
+      await queryClient.invalidateQueries({ queryKey: ["campaigns"] });
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Redistribute failed");
+    } finally {
+      setApplying(false);
+    }
+  }
+
+  // Build synthetic Post[] from preview mapping for the proposed timeline.
+  const previewPosts: Post[] = useMemo(() => {
+    if (!preview) return [];
+    return preview.mapping.map((m) => ({
+      id: m.postId,
+      title: "",
+      campaignIds: [campaign.id],
+      // CampaignTimeline maps lowercase platform via fallback → same color
+      platform: m.platform,
+      content: "",
+      mediaUrls: "",
+      mediaCaptions: "",
+      imageUrl: "",
+      shortUrl: "",
+      linkUrl: "",
+      scheduledDate: m.newDate,
+      status: "Scheduled" as PostStatus,
+      contentVariant: "",
+      approvedBy: "",
+      approvedAt: "",
+      zernioPostId: "",
+      notes: "",
+      originalMedia: "",
+      coverSlideData: "",
+      firstComment: "",
+      sortOrder: null,
+      platformPostUrl: "",
+      collaborators: "",
+      userTags: "",
+      lnkBioSyncPending: false,
+      lnkBioEntryId: "",
+      carouselPdfUrl: "",
+      subject: "",
+      imageIndex: null,
+    } as unknown as Post));
+  }, [preview, campaign.id]);
+
+  const newWindowStart = preview
+    ? new Date(preview.startDate + "T00:00:00")
+    : new Date(startDate + "T00:00:00");
+
+  const datesValid = (() => {
+    if (!startDate || !endDate) return false;
+    return new Date(endDate) > new Date(startDate);
+  })();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <CalendarRange className="h-5 w-5" />
+            Redistribute campaign schedule
+          </DialogTitle>
+          <DialogDescription>
+            Re-spread {participantCount} post{participantCount === 1 ? "" : "s"} (Approved + Scheduled) across a new window.
+            Brand-wide collisions and platform cadence are respected. Published posts are not moved.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="redistribute-start">Start date</Label>
+              <Input
+                id="redistribute-start"
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                min={ymd(today)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="redistribute-end">End date</Label>
+              <Input
+                id="redistribute-end"
+                type="date"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                min={startDate}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="redistribute-bias">Distribution bias</Label>
+            <Select value={bias} onValueChange={(v) => setBias(v as DistributionBias)}>
+              <SelectTrigger id="redistribute-bias">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {BIAS_OPTIONS.map((b) => (
+                  <SelectItem key={b.value} value={b.value}>
+                    <span className="font-medium">{b.label}</span>
+                    <span className="text-xs text-muted-foreground ml-2">{b.description}</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {previewError && (
+            <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {previewError}
+            </div>
+          )}
+
+          {preview && (
+            <div className="space-y-3 rounded-md border bg-muted/30 p-3">
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                <span>
+                  <strong className="text-foreground">{preview.participantCount}</strong> posts to re-place
+                </span>
+                <span>
+                  <strong className="text-foreground">{preview.externalCollisionCount}</strong> brand-wide collisions respected
+                </span>
+                {preview.reservationCount > 0 && (
+                  <span>
+                    <strong className="text-foreground">{preview.reservationCount}</strong> Pending reservations
+                  </span>
+                )}
+                <span>
+                  <strong className="text-foreground">{preview.durationDays}</strong> days · {preview.distributionBias}
+                </span>
+              </div>
+              <div>
+                <div className="text-[11px] text-muted-foreground uppercase tracking-wider mb-1.5">
+                  Proposed timeline
+                </div>
+                <CampaignTimeline
+                  posts={previewPosts}
+                  campaignStartDate={newWindowStart}
+                  durationDays={preview.durationDays}
+                  campaignId={campaign.id}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={applying}
+          >
+            Cancel
+          </Button>
+          {!preview ? (
+            <Button
+              onClick={handlePreview}
+              disabled={!datesValid || previewing || participantCount === 0}
+            >
+              {previewing ? (
+                <><Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> Computing…</>
+              ) : (
+                "Preview"
+              )}
+            </Button>
+          ) : (
+            <Button onClick={handleApply} disabled={applying}>
+              {applying ? (
+                <><Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> Applying…</>
+              ) : (
+                `Confirm — apply to ${preview.mapping.length} post${preview.mapping.length === 1 ? "" : "s"}`
+              )}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/__tests__/api-throttle.test.ts
+++ b/src/lib/__tests__/api-throttle.test.ts
@@ -25,13 +25,13 @@ describe("api-throttle minimum interval", () => {
     expect(elapsed).toBeGreaterThanOrEqual(4 * 220 - 5);
   });
 
-  it("Zernio throttle (1100ms): 3 sequential calls take ≥ 2 × 1100ms", async () => {
-    await new Promise((r) => setTimeout(r, 2300));
+  it("Zernio throttle (500ms): 3 sequential calls take ≥ 2 × 500ms", async () => {
+    await new Promise((r) => setTimeout(r, 1100));
     const start = Date.now();
     for (let i = 0; i < 3; i++) await zernioThrottle.wait();
     const elapsed = Date.now() - start;
-    expect(elapsed).toBeGreaterThanOrEqual(2 * 1100 - 5);
-  }, 10_000);
+    expect(elapsed).toBeGreaterThanOrEqual(2 * 500 - 5);
+  });
 
   it("lnk.bio throttle (500ms): 4 sequential calls take ≥ 3 × 500ms", async () => {
     await new Promise((r) => setTimeout(r, 1100));

--- a/src/lib/__tests__/api-throttle.test.ts
+++ b/src/lib/__tests__/api-throttle.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Validates the per-API throttle's correctness contract:
+ *   - First call passes through immediately.
+ *   - Subsequent calls within the minimum interval are delayed.
+ *   - Calls separated by ≥ minimum interval pass through immediately.
+ *   - Concurrent waiters serialize (no race on lastCallTime).
+ */
+
+import { describe, it, expect } from "vitest";
+import { airtableThrottle, zernioThrottle, lnkBioThrottle } from "@/lib/api-throttle";
+
+// Trade isolation for speed: we share the module-singleton throttles
+// across tests, so tests must run sequentially within a describe block
+// (vitest default). Each `it` does its own sequential timing assertion.
+
+describe("api-throttle minimum interval", () => {
+  it("Airtable throttle (220ms): 5 sequential calls take ≥ 4 × 220ms", async () => {
+    // First call has no prior — passes through. Calls 2..5 each wait 220ms.
+    // Reset by waiting 1s before the test (so any prior lastCallTime is stale).
+    await new Promise((r) => setTimeout(r, 1100));
+
+    const start = Date.now();
+    for (let i = 0; i < 5; i++) await airtableThrottle.wait();
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(4 * 220 - 5);
+  });
+
+  it("Zernio throttle (1100ms): 3 sequential calls take ≥ 2 × 1100ms", async () => {
+    await new Promise((r) => setTimeout(r, 2300));
+    const start = Date.now();
+    for (let i = 0; i < 3; i++) await zernioThrottle.wait();
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(2 * 1100 - 5);
+  }, 10_000);
+
+  it("lnk.bio throttle (500ms): 4 sequential calls take ≥ 3 × 500ms", async () => {
+    await new Promise((r) => setTimeout(r, 1100));
+    const start = Date.now();
+    for (let i = 0; i < 4; i++) await lnkBioThrottle.wait();
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(3 * 500 - 5);
+  });
+
+  it("concurrent waiters serialize (don't race on lastCallTime)", async () => {
+    await new Promise((r) => setTimeout(r, 1100));
+    // Fire 4 waits in parallel — they should still serialize under the minimum interval.
+    const start = Date.now();
+    await Promise.all(Array.from({ length: 4 }, () => airtableThrottle.wait()));
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(3 * 220 - 5);
+  });
+});

--- a/src/lib/__tests__/scheduling.test.ts
+++ b/src/lib/__tests__/scheduling.test.ts
@@ -770,6 +770,14 @@ describe("Phase D: external-collision mode (additiveMode: false, default)", () =
   it("additiveMode: false vs true — same inputs, different shape", () => {
     // Identical setup except for the flag. Confirms the two modes are
     // genuinely distinct, not silently merged behavior.
+    //
+    // Setup: Front-loaded, existing 1 on day 0, maxPerDay=4.
+    //   - additiveMode: true → total=5, ideal[0] = 0.213·5 ≈ 1.07,
+    //     placedPerDay[0] starts at 1 → deficit[0] ≈ 0.07. Day 1 deficit ≈ 0.85.
+    //     Algorithm prefers day 1 first.
+    //   - additiveMode: false → total=4, ideal[0] = 0.213·4 ≈ 0.85,
+    //     placedPerDay[0] starts at 0 → deficit[0] ≈ 0.85. Algorithm picks
+    //     day 0 first (existing doesn't reshape the ideal).
     const cadence: PlatformCadenceConfig = {
       instagram: {
         postsPerWeek: 28,
@@ -777,15 +785,14 @@ describe("Phase D: external-collision mode (additiveMode: false, default)", () =
         timeWindows: ["morning", "afternoon", "evening"],
       },
     };
-    // Existing 4 on days 10-13 (back end)
     const excluded = new Map<string, Map<string, number>>();
-    excluded.set("instagram", makeExisting(START, { 10: 1, 11: 1, 12: 1, 13: 1 }));
+    excluded.set("instagram", makeExisting(START, { 0: 1 }));
 
     const additiveTrue = schedulePostsAlgorithm({
       posts: makePosts(["instagram"], 4),
       startDate: START,
       durationDays: 14,
-      bias: "Balanced",
+      bias: "Front-loaded",
       cadence,
       excludedDates: excluded,
       additiveMode: true,
@@ -794,15 +801,77 @@ describe("Phase D: external-collision mode (additiveMode: false, default)", () =
       posts: makePosts(["instagram"], 4),
       startDate: START,
       durationDays: 14,
-      bias: "Balanced",
+      bias: "Front-loaded",
       cadence,
       excludedDates: excluded,
       additiveMode: false,
     });
 
-    // additiveMode: true (deficit-fill on balanced) vs false (Phase A midpoint
-    // on balanced curve) place posts differently. Distributions should diverge.
     expect(countByDay(additiveTrue, START, 14))
       .not.toEqual(countByDay(additiveFalse, START, 14));
+  });
+});
+
+// ── 9. Intersect-shape regression — global deficit-fill produces smooth taper ──
+//
+// Reproduces the real-world scenario that exposed the per-platform-quantile
+// barbell: 14-day Front-loaded, 19 posts across 6 platforms (5 weekday-only +
+// 1 all-day-active Pinterest), maxPerDay=1. The new global deficit-fill
+// algorithm must produce a smooth taper, not a barbell. (Phase A's per-
+// platform midpoint quantile passed unit tests but failed this real shape.)
+
+describe("regression: global deficit-fill produces a smooth taper under Intersect-shape input", () => {
+  it("19 posts × 6 platforms × 14 days × Front-loaded → no back cluster, sparse middle filled", () => {
+    // Mirror The Intersect's cadence: 5 weekday-only platforms with
+    // postsPerWeek=4 (maxPerDay=1) + Pinterest all-day-active with
+    // postsPerWeek=4 (maxPerDay=1).
+    const cadence: PlatformCadenceConfig = {
+      instagram: { postsPerWeek: 4, activeDays: [1, 2, 3, 4, 5], timeWindows: ["morning", "afternoon"] },
+      bluesky: { postsPerWeek: 4, activeDays: [1, 2, 3, 4, 5], timeWindows: ["morning", "afternoon"] },
+      threads: { postsPerWeek: 4, activeDays: [1, 2, 3, 4, 5], timeWindows: ["morning", "afternoon"] },
+      facebook: { postsPerWeek: 4, activeDays: [1, 2, 3, 4, 5], timeWindows: ["afternoon"] },
+      linkedin: { postsPerWeek: 4, activeDays: [1, 2, 3, 4, 5], timeWindows: ["morning", "afternoon"] },
+      pinterest: { postsPerWeek: 4, activeDays: [], timeWindows: ["evening"] },
+    };
+    // 19 posts: bluesky 4, instagram 3, threads 3, facebook 3, linkedin 3, pinterest 3
+    const posts: ScheduleInput["posts"] = [
+      ...Array.from({ length: 4 }, (_, i) => ({ id: `bs-${i}`, platform: "bluesky" })),
+      ...Array.from({ length: 3 }, (_, i) => ({ id: `ig-${i}`, platform: "instagram" })),
+      ...Array.from({ length: 3 }, (_, i) => ({ id: `th-${i}`, platform: "threads" })),
+      ...Array.from({ length: 3 }, (_, i) => ({ id: `fb-${i}`, platform: "facebook" })),
+      ...Array.from({ length: 3 }, (_, i) => ({ id: `li-${i}`, platform: "linkedin" })),
+      ...Array.from({ length: 3 }, (_, i) => ({ id: `pi-${i}`, platform: "pinterest" })),
+    ];
+    // Apr 28 2026 = Tuesday → 14-day window has 10 weekdays + 4 weekend days
+    const start = new Date(2026, 3, 28);
+    const slots = schedulePostsAlgorithm({
+      posts,
+      startDate: start,
+      durationDays: 14,
+      bias: "Front-loaded",
+      cadence,
+    });
+
+    expect(slots).toHaveLength(19);
+
+    const counts = countByDay(slots, start, 14);
+    const total = counts.reduce((a, b) => a + b, 0);
+
+    // Front half should hold ≥ 70% of posts (Front-loaded with this curve has
+    // roughly 80% mass in first half over 14 days).
+    const front = counts.slice(0, 7).reduce((a, b) => a + b, 0);
+    expect(front / total).toBeGreaterThanOrEqual(0.7);
+
+    // No "back cluster": last 3 days combined must hold < 15% of total.
+    const back3 = counts[11] + counts[12] + counts[13];
+    expect(back3 / total).toBeLessThan(0.15);
+
+    // Specifically: day 13 (final day) cannot exceed day 0.
+    expect(counts[13]).toBeLessThanOrEqual(counts[0]);
+
+    // Smoothness: no single day in the last half should exceed 3 posts
+    // (catches the 6-on-final-day barbell pattern).
+    const lastHalfMax = Math.max(...counts.slice(7));
+    expect(lastHalfMax).toBeLessThanOrEqual(3);
   });
 });

--- a/src/lib/__tests__/scheduling.test.ts
+++ b/src/lib/__tests__/scheduling.test.ts
@@ -444,6 +444,7 @@ describe("Phase B: density-aware additive scheduling", () => {
       bias: "Front-loaded",
       cadence,
       excludedDates: excluded,
+      additiveMode: true,
     });
     expect(slots).toHaveLength(4);
 
@@ -473,6 +474,7 @@ describe("Phase B: density-aware additive scheduling", () => {
       bias: "Front-loaded",
       cadence,
       excludedDates: excluded,
+      additiveMode: true,
     });
     expect(slots).toHaveLength(4);
     for (const s of slots) {
@@ -507,6 +509,7 @@ describe("Phase B: density-aware additive scheduling", () => {
       bias: "Front-loaded",
       cadence,
       excludedDates: excluded,
+      additiveMode: true,
     });
 
     const avg = (xs: { scheduledDate: string }[]) =>
@@ -551,6 +554,7 @@ describe("Phase B: density-aware additive scheduling", () => {
       bias: "Front-loaded",
       cadence,
       excludedDates: excluded,
+      additiveMode: true,
     });
     expect(additive5).toHaveLength(5);
 
@@ -601,6 +605,7 @@ describe("Phase B: density-aware additive scheduling", () => {
       bias: "Front-loaded",
       cadence,
       excludedDates: excluded,
+      additiveMode: true,
     });
     expect(slots).toHaveLength(5);
 
@@ -641,6 +646,7 @@ describe("Phase B: density-aware additive scheduling", () => {
       bias: "Balanced",
       cadence,
       excludedDates: excluded,
+      additiveMode: true,
     });
     expect(slots).toHaveLength(6);
 
@@ -686,5 +692,117 @@ describe("Phase B: density-aware additive scheduling", () => {
     });
 
     expect(countByDay(a, START, 14)).toEqual(countByDay(bWithEmpty, START, 14));
+  });
+});
+
+// ── 8. Phase D: redistribute mode (#178) — externals as pure collisions ──
+
+describe("Phase D: external-collision mode (additiveMode: false, default)", () => {
+  it("externals don't shift the curve target — front-loaded stays front-loaded", () => {
+    // Brand-wide other-campaign posts on days 0-3 (early). Without additiveMode,
+    // these should ONLY block via maxPerDay (not in this scenario since cadence
+    // is loose), and the new posts should still front-load per the curve.
+    const cadence: PlatformCadenceConfig = {
+      instagram: {
+        postsPerWeek: 70, // maxPerDay=10, very loose
+        activeDays: [],
+        timeWindows: ["morning", "afternoon", "evening"],
+      },
+    };
+    const externals = new Map<string, Map<string, number>>();
+    externals.set("instagram", makeExisting(START, { 0: 1, 1: 1, 2: 1, 3: 1 }));
+
+    // additiveMode default false: externals are collision-only, don't shape curve
+    const redistributed = schedulePostsAlgorithm({
+      posts: makePosts(["instagram"], 4),
+      startDate: START,
+      durationDays: 14,
+      bias: "Front-loaded",
+      cadence,
+      excludedDates: externals,
+    });
+    // Compare to first-time scheduling with no externals at all
+    const firstTime = schedulePostsAlgorithm({
+      posts: makePosts(["instagram"], 4),
+      startDate: START,
+      durationDays: 14,
+      bias: "Front-loaded",
+      cadence,
+    });
+
+    // The two day-distributions should be identical — externals don't reshape
+    // the curve when additiveMode is off.
+    expect(countByDay(redistributed, START, 14))
+      .toEqual(countByDay(firstTime, START, 14));
+  });
+
+  it("externals still enforce maxPerDay (collision constraint applies)", () => {
+    // maxPerDay=1. Externals on days 0-3 saturate them. New posts must spill
+    // past day 3 even though front-loaded curve wants to put them early.
+    const cadence: PlatformCadenceConfig = {
+      instagram: {
+        postsPerWeek: 7,
+        activeDays: [],
+        timeWindows: ["morning", "afternoon"],
+      },
+    };
+    const externals = new Map<string, Map<string, number>>();
+    externals.set("instagram", makeExisting(START, { 0: 1, 1: 1, 2: 1, 3: 1 }));
+
+    const slots = schedulePostsAlgorithm({
+      posts: makePosts(["instagram"], 4),
+      startDate: START,
+      durationDays: 14,
+      bias: "Front-loaded",
+      cadence,
+      excludedDates: externals,
+      additiveMode: false, // explicit
+    });
+    expect(slots).toHaveLength(4);
+
+    // No new post on the externally-occupied days (maxPerDay=1 walked outward)
+    for (const s of slots) {
+      const off = dayOffset(s.scheduledDate, START);
+      expect(off).toBeGreaterThanOrEqual(4);
+    }
+  });
+
+  it("additiveMode: false vs true — same inputs, different shape", () => {
+    // Identical setup except for the flag. Confirms the two modes are
+    // genuinely distinct, not silently merged behavior.
+    const cadence: PlatformCadenceConfig = {
+      instagram: {
+        postsPerWeek: 28,
+        activeDays: [],
+        timeWindows: ["morning", "afternoon", "evening"],
+      },
+    };
+    // Existing 4 on days 10-13 (back end)
+    const excluded = new Map<string, Map<string, number>>();
+    excluded.set("instagram", makeExisting(START, { 10: 1, 11: 1, 12: 1, 13: 1 }));
+
+    const additiveTrue = schedulePostsAlgorithm({
+      posts: makePosts(["instagram"], 4),
+      startDate: START,
+      durationDays: 14,
+      bias: "Balanced",
+      cadence,
+      excludedDates: excluded,
+      additiveMode: true,
+    });
+    const additiveFalse = schedulePostsAlgorithm({
+      posts: makePosts(["instagram"], 4),
+      startDate: START,
+      durationDays: 14,
+      bias: "Balanced",
+      cadence,
+      excludedDates: excluded,
+      additiveMode: false,
+    });
+
+    // additiveMode: true (deficit-fill on balanced) vs false (Phase A midpoint
+    // on balanced curve) place posts differently. Distributions should diverge.
+    expect(countByDay(additiveTrue, START, 14))
+      .not.toEqual(countByDay(additiveFalse, START, 14));
   });
 });

--- a/src/lib/airtable/client.ts
+++ b/src/lib/airtable/client.ts
@@ -1,6 +1,7 @@
 // Airtable REST API client for server-side use
 
 import type { UserProfile, UserRole } from "./types";
+import { airtableThrottle } from "@/lib/api-throttle";
 
 const AIRTABLE_PAT = process.env.AIRTABLE_API_KEY!;
 const AIRTABLE_BASE_ID = process.env.AIRTABLE_BASE_ID!;
@@ -17,28 +18,62 @@ interface AirtableListResponse<T = Record<string, unknown>> {
   offset?: string;
 }
 
+/**
+ * Airtable's per-base rate limit is 5 req/sec. Bursting past it returns
+ * a 429 with `Retry-After` (seconds). We retry up to 3 times with
+ * exponential backoff, honoring the header when present. This protects
+ * batch routes (redistribute, schedule, etc.) from cascading failures
+ * when many records are touched in one user action.
+ */
+const AIRTABLE_MAX_RETRIES = 3;
+const AIRTABLE_BASE_BACKOFF_MS = 500;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function airtableFetch<T>(
   path: string,
   options?: RequestInit
 ): Promise<T> {
   const url = `${AIRTABLE_API_URL}/${AIRTABLE_BASE_ID}${path}`;
-  const res = await fetch(url, {
-    ...options,
-    headers: {
-      Authorization: `Bearer ${AIRTABLE_PAT}`,
-      "Content-Type": "application/json",
-      ...options?.headers,
-    },
-  });
+  let lastError: unknown = null;
 
-  if (!res.ok) {
+  for (let attempt = 0; attempt <= AIRTABLE_MAX_RETRIES; attempt++) {
+    // Hard rate-limit gate: never call Airtable faster than 4.5 req/sec.
+    await airtableThrottle.wait();
+    const res = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${AIRTABLE_PAT}`,
+        "Content-Type": "application/json",
+        ...options?.headers,
+      },
+    });
+
+    if (res.ok) return res.json();
+
+    if (res.status === 429 && attempt < AIRTABLE_MAX_RETRIES) {
+      // Honor Retry-After if present (seconds), else exponential backoff.
+      const retryAfterHeader = res.headers.get("Retry-After");
+      const retryAfterSec = retryAfterHeader ? Number(retryAfterHeader) : NaN;
+      const waitMs = Number.isFinite(retryAfterSec) && retryAfterSec > 0
+        ? retryAfterSec * 1000
+        : AIRTABLE_BASE_BACKOFF_MS * 2 ** attempt;
+      console.warn(`[airtable] 429 on ${path}; retry in ${waitMs}ms (attempt ${attempt + 1}/${AIRTABLE_MAX_RETRIES})`);
+      await sleep(waitMs);
+      continue;
+    }
+
+    // Non-429 error or out of retries — fail.
     const error = await res.json().catch(() => ({ error: res.statusText }));
-    throw new Error(
-      `Airtable API error: ${res.status} ${JSON.stringify(error)}`
+    lastError = new Error(
+      `Airtable API error: ${res.status} ${JSON.stringify(error)}`,
     );
+    break;
   }
 
-  return res.json();
+  throw lastError ?? new Error("Airtable request failed after retries");
 }
 
 export async function listRecords<T = Record<string, unknown>>(

--- a/src/lib/api-throttle.ts
+++ b/src/lib/api-throttle.ts
@@ -1,0 +1,57 @@
+/**
+ * Per-external-API minimum-interval throttle. Guarantees a hard floor
+ * between successive calls to one API regardless of caller pattern, so
+ * batch routes (redistribute, schedule, generate) cannot blow through
+ * provider rate limits.
+ *
+ * Scope: per Node.js module instance. Within a single Vercel function
+ * invocation this is a hard guarantee. Across concurrent invocations
+ * (e.g., two users hitting redistribute simultaneously) each lambda
+ * has its own tracker — for that case, the per-client retry-on-429
+ * logic absorbs collisions.
+ *
+ * Concurrency-safe within a single invocation via a serial wait chain:
+ * concurrent `wait()` calls queue, they don't race on `lastCallTime`.
+ */
+class ApiThrottle {
+  private lastCallTime = 0;
+  private waitChain: Promise<void> = Promise.resolve();
+
+  constructor(private readonly minIntervalMs: number) {}
+
+  async wait(): Promise<void> {
+    const myTurn = this.waitChain.then(async () => {
+      const now = Date.now();
+      const elapsed = now - this.lastCallTime;
+      if (elapsed < this.minIntervalMs) {
+        await new Promise<void>((r) => setTimeout(r, this.minIntervalMs - elapsed));
+      }
+      this.lastCallTime = Date.now();
+    });
+    // Never let the chain reject (a thrown error mid-wait would poison it).
+    this.waitChain = myTurn.catch(() => undefined);
+    return myTurn;
+  }
+}
+
+// ── Configured limiters per API ──────────────────────────────────────
+//
+// Numbers chosen to stay strictly under documented limits with margin.
+// They add latency proportional to call count; that's the explicit
+// trade-off — guaranteed safety over speed.
+
+/** Airtable: 5 req/sec per base. 220ms = 4.5 req/sec → safe. */
+export const airtableThrottle = new ApiThrottle(220);
+
+/**
+ * Zernio: Free tier 60/min (1/sec), Build tier 120/min (2/sec). We don't
+ * know which tier the deployed key is on, so target the Free tier with
+ * margin: 1100ms = ~0.9 req/sec → safe under Free.
+ */
+export const zernioThrottle = new ApiThrottle(1100);
+
+/**
+ * lnk.bio: rate limit undocumented; the dashboard is responsive at ~2 req/sec
+ * in practice. 500ms = 2 req/sec is a conservative ceiling.
+ */
+export const lnkBioThrottle = new ApiThrottle(500);

--- a/src/lib/api-throttle.ts
+++ b/src/lib/api-throttle.ts
@@ -44,11 +44,19 @@ class ApiThrottle {
 export const airtableThrottle = new ApiThrottle(220);
 
 /**
- * Zernio: Free tier 60/min (1/sec), Build tier 120/min (2/sec). We don't
- * know which tier the deployed key is on, so target the Free tier with
- * margin: 1100ms = ~0.9 req/sec → safe under Free.
+ * Zernio: per Perplexity research (2026-04-29), Zernio does not publish
+ * per-second/per-minute rate limits — only monthly post quotas and daily
+ * Tools API quotas. The deployed brand keys are on the Dominate AppSumo
+ * tier (= Accelerate plan: unlimited posts, 500 Tools API calls/day).
+ * Empirically, the existing /schedule route fires sequential createPost
+ * calls without throttling and has been stable.
+ *
+ * 500ms (2 req/sec) is a defensive ceiling — well within what production
+ * traffic has shown stable, and gives 19-post redistribute runs ~25–30s
+ * wall-clock. If a 429 ever does come back, the route surfaces it as
+ * a per-post failure and the user can retry.
  */
-export const zernioThrottle = new ApiThrottle(1100);
+export const zernioThrottle = new ApiThrottle(500);
 
 /**
  * lnk.bio: rate limit undocumented; the dashboard is responsive at ~2 req/sec

--- a/src/lib/late-api/types.ts
+++ b/src/lib/late-api/types.ts
@@ -49,12 +49,15 @@ export const PLATFORM_NAMES: Record<Platform, string> = {
 };
 
 // Light mode colors (used on light backgrounds)
+// Instagram + Pinterest were both pure red and visually conflated on the
+// timeline (#209). Instagram now leans orange (its gradient's warm anchor)
+// and Pinterest is slightly darker red, giving clear hue separation.
 export const PLATFORM_COLORS: Record<Platform, string> = {
-  instagram: "#E4405F",
+  instagram: "#F56040",
   tiktok: "#000000",
   youtube: "#FF0000",
   linkedin: "#0A66C2",
-  pinterest: "#E60023",
+  pinterest: "#C8001B",
   twitter: "#000000",
   facebook: "#1877F2",
   threads: "#000000",
@@ -67,11 +70,11 @@ export const PLATFORM_COLORS: Record<Platform, string> = {
 
 // Dark mode colors (lighter versions for dark backgrounds)
 export const PLATFORM_COLORS_DARK: Record<Platform, string> = {
-  instagram: "#F77A94",
+  instagram: "#FFA277",
   tiktok: "#FFFFFF",
   youtube: "#FF4444",
   linkedin: "#5AA9E6",
-  pinterest: "#FF4D6A",
+  pinterest: "#FF5757",
   twitter: "#FFFFFF",
   facebook: "#4599FF",
   threads: "#FFFFFF",

--- a/src/lib/lnk-bio.ts
+++ b/src/lib/lnk-bio.ts
@@ -17,6 +17,8 @@
  *   GET  /oauth/v1/group/list                  — list groups on authenticated profile
  */
 
+import { lnkBioThrottle } from "@/lib/api-throttle";
+
 const API_BASE = "https://lnk.bio/oauth/v1";
 const TOKEN_URL = "https://lnk.bio/oauth/token";
 
@@ -72,6 +74,7 @@ async function getAccessToken(creds: LnkBioCredentials): Promise<string> {
   if (cached && Date.now() < cached.expiresAt - 60_000) return cached.accessToken;
 
   const basicAuth = Buffer.from(`${creds.clientId}:${creds.clientSecret}`).toString("base64");
+  await lnkBioThrottle.wait();
   const res = await fetch(TOKEN_URL, {
     method: "POST",
     headers: {
@@ -110,6 +113,7 @@ async function lnkBioRequest(
       "application/x-www-form-urlencoded";
     options.body = new URLSearchParams(data).toString();
   }
+  await lnkBioThrottle.wait();
   const res = await fetch(`${API_BASE}${path}`, options);
   if (!res.ok) {
     const text = await res.text();

--- a/src/lib/post-apply.ts
+++ b/src/lib/post-apply.ts
@@ -12,6 +12,7 @@
  */
 import { getRecord, updateRecord } from "@/lib/airtable/client";
 import { createBrandClient } from "@/lib/late-api/client";
+import { zernioThrottle } from "@/lib/api-throttle";
 import {
   assembleCarouselPDF,
   prepareLinkedInPdfMetadata,
@@ -262,6 +263,7 @@ async function syncZernio(
 
   // Resolve accountId from the live Zernio post — replacing platforms[]
   // without it nullifies the account link.
+  await zernioThrottle.wait();
   const { data: existing } = await client.posts.getPost({ path: { postId: zernioPostId } });
   const existingPlatform = (
     existing as { post?: { platforms?: Array<{ platform?: string; accountId?: string | { _id: string } }> } }
@@ -279,6 +281,7 @@ async function syncZernio(
     updateBody.platforms = [{ platform, accountId, platformSpecificData: psd }];
   }
 
+  await zernioThrottle.wait();
   const { error } = await client.posts.updatePost({
     path: { postId: zernioPostId },
     body: updateBody,

--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -202,61 +202,43 @@ function isDayActive(date: Date, cadence: ResolvedCadence): boolean {
   return cadence.activeDays.includes(date.getDay());
 }
 
-/**
- * Find the index in `validDays` whose cumulative weight first reaches the target.
- */
-function cdfInvert(cumulative: number[], target: number): number {
-  for (let j = 0; j < cumulative.length; j++) {
-    if (cumulative[j] >= target) return j;
-  }
-  return cumulative.length - 1;
-}
-
-/**
- * Walk outward from `preferredIdx` to the nearest valid-day index whose count is
- * still below `maxPerDay`. When both sides have a candidate at the same offset,
- * prefer the heavier curve weight (closer to the curve's intent).
- */
-function findAvailableDayIdx(
-  preferredIdx: number,
-  validDays: number[],
-  dayCounts: Map<number, number>,
-  maxPerDay: number,
-  weights: number[],
-): number {
-  const isOpen = (idx: number) =>
-    idx >= 0 &&
-    idx < validDays.length &&
-    (dayCounts.get(validDays[idx]) || 0) < maxPerDay;
-
-  if (isOpen(preferredIdx)) return preferredIdx;
-
-  for (let offset = 1; offset < validDays.length; offset++) {
-    const left = preferredIdx - offset;
-    const right = preferredIdx + offset;
-    const leftOpen = isOpen(left);
-    const rightOpen = isOpen(right);
-    if (leftOpen && rightOpen) {
-      return weights[left] >= weights[right] ? left : right;
-    }
-    if (leftOpen) return left;
-    if (rightOpen) return right;
-  }
-  // No room anywhere — best-effort fallback (over-allocates the preferred day).
-  return preferredIdx;
-}
-
 // ── Main scheduling function ──────────────────────────────────────────
+
+interface PlatformState {
+  cadence: ResolvedCadence;
+  posts: Array<{ id: string; platform: string; sortOrder?: number | null }>;
+  /** True if this day-offset is active for this platform. Length === durationDays. */
+  activeMask: boolean[];
+  /** Per day-offset: count of posts on this day (existing + placed-this-run). */
+  dayCounts: Map<number, number>;
+  /** Per day-offset: decimal hours already placed (for minSpacing checks). */
+  dayTimes: Map<number, number[]>;
+  /** Day-offsets where this run has placed a post (in placement order). */
+  placedDayOffsets: number[];
+}
 
 /**
  * Distribute approved posts across the campaign timeline.
  *
- * Algorithm:
- * 1. Group posts by platform
- * 2. Generate a tapering curve for the campaign duration
- * 3. For each platform, distribute its posts across days proportionally
- *    to the curve weights, respecting per-platform cadence
- * 4. Assign specific times using organic variation
+ * Uses **global cross-platform greedy deficit-fill** rather than per-platform
+ * independent quantile sampling. Each iteration picks the (platform, day)
+ * pair with the largest deficit (`ideal[d] − placed[d]` aggregate) subject
+ * to per-platform constraints. Avoids the synchronized-clustering pattern
+ * that pure per-platform sampling produces — every platform sharing the
+ * same curve no longer drives every platform's last quantile onto the same
+ * tail-end days.
+ *
+ * Steps:
+ * 1. Group posts by platform; preserve user `sortOrder` within each group.
+ * 2. Generate aggregate ideal curve (one curve, scaled to total post count).
+ * 3. For each placement, scan all (platform, day) pairs and pick the one
+ *    that fills the most deficit. Tie-break by the platform that has placed
+ *    the fewest posts so far (round-robin fairness), then earliest day,
+ *    then deterministic platform name.
+ * 4. After all placements, zip each platform's day-list (sorted ascending)
+ *    with its sortOrder-sorted posts so post[sortOrder=0] gets the earliest
+ *    day for that platform, post[sortOrder=1] the next, etc.
+ * 5. Pick a time-of-day per slot using cadence windows + minSpacing.
  */
 export function schedulePostsAlgorithm(input: ScheduleInput): ScheduleSlot[] {
   const {
@@ -271,149 +253,178 @@ export function schedulePostsAlgorithm(input: ScheduleInput): ScheduleSlot[] {
 
   if (posts.length === 0 || durationDays <= 0) return [];
 
-  // Group posts by platform, then sort by sortOrder (ascending, nulls last)
-  const byPlatform = new Map<string, Array<{ id: string; platform: string; sortOrder?: number | null }>>();
+  // ── 1. Group + sort posts per platform by sortOrder ────────────────
+  const byPlatform = new Map<
+    string,
+    Array<{ id: string; platform: string; sortOrder?: number | null }>
+  >();
   for (const post of posts) {
-    const existing = byPlatform.get(post.platform) || [];
-    existing.push(post);
-    byPlatform.set(post.platform, existing);
+    const list = byPlatform.get(post.platform) ?? [];
+    list.push(post);
+    byPlatform.set(post.platform, list);
   }
-  for (const [, platformPosts] of byPlatform) {
-    platformPosts.sort((a, b) => {
-      const aOrder = a.sortOrder ?? Infinity;
-      const bOrder = b.sortOrder ?? Infinity;
-      return aOrder - bOrder;
+  for (const [, list] of byPlatform) {
+    list.sort((a, b) => {
+      const ao = a.sortOrder ?? Infinity;
+      const bo = b.sortOrder ?? Infinity;
+      return ao - bo;
     });
   }
 
-  // Generate the tapering curve
+  // Curve over the full durationDays — single aggregate target shared across
+  // all platforms (the key change vs. the previous per-platform approach).
   const curve = generateCurve(durationDays, bias);
 
-  const slots: ScheduleSlot[] = [];
-
+  // ── 2. Build per-platform state ─────────────────────────────────────
+  const states = new Map<string, PlatformState>();
   for (const [platform, platformPosts] of byPlatform) {
     const cadence = resolveCadence(platform, cadenceConfig);
-    const postCount = platformPosts.length;
-
-    // Build the platform's working state:
-    // - validDays: day offsets allowed by activeDays
-    // - dayCounts: per-day count (pre-loaded from excludedDates, mutated as we place)
-    // - dayTimes: per-day list of decimal hours already placed (for spacing)
     const platformExcluded = excludedDates?.get(platform);
-    const validDays: number[] = [];
+    const activeMask: boolean[] = [];
     const dayCounts = new Map<number, number>();
-    const dayTimes = new Map<number, number[]>();
 
     for (let d = 0; d < durationDays; d++) {
       const date = new Date(startDate);
       date.setDate(date.getDate() + d);
-      if (!isDayActive(date, cadence)) continue;
-      validDays.push(d);
-      if (platformExcluded) {
+      const isActive = isDayActive(date, cadence);
+      activeMask.push(isActive);
+      if (isActive && platformExcluded) {
         const dateStr = date.toISOString().split("T")[0];
         const existing = platformExcluded.get(dateStr) ?? 0;
         if (existing > 0) dayCounts.set(d, existing);
       }
     }
 
-    if (validDays.length === 0) continue;
+    states.set(platform, {
+      cadence,
+      posts: platformPosts,
+      activeMask,
+      dayCounts,
+      dayTimes: new Map(),
+      placedDayOffsets: [],
+    });
+  }
 
-    // Curve weights normalized over valid days
-    const validWeights = validDays.map((d) => curve[d]);
-    const totalWeight = validWeights.reduce((a, b) => a + b, 0);
-    const curveNormalized = validWeights.map((w) => w / totalWeight);
+  // ── 3. Compute global ideal curve ───────────────────────────────────
+  // Aggregate target = curve × (newPostCount + existing-counted-toward-curve).
+  // additiveMode: true → existing posts are part of the same campaign's
+  //   distribution target, so they contribute to total. (#84 Phase 2)
+  // additiveMode: false → existing in excludedDates are external collisions
+  //   (other-campaign posts, reservations) — they constrain caps but do NOT
+  //   reshape this campaign's curve target. (#178 redistribute)
+  let curveTotalCount = posts.length;
+  if (additiveMode) {
+    for (const [, s] of states) {
+      for (const [, count] of s.dayCounts) curveTotalCount += count;
+    }
+  }
+  const idealPerDay = curve.map((w) => w * curveTotalCount);
 
-    const totalExisting = [...dayCounts.values()].reduce((a, b) => a + b, 0);
-
-    // Closure: place the i-th platform post at the given valid-day index.
-    // Mutates dayCounts/dayTimes/slots; reads platformPosts[i] and cadence.
-    let placedCount = 0;
-    const placeAt = (dayIdx: number) => {
-      const dayOffset = validDays[dayIdx];
-      dayCounts.set(dayOffset, (dayCounts.get(dayOffset) ?? 0) + 1);
-      const date = new Date(startDate);
-      date.setDate(date.getDate() + dayOffset);
-      const timesOnDay = dayTimes.get(dayOffset) ?? [];
-      const time = pickTimeWithSpacing(cadence, timesOnDay);
-      date.setHours(time.hour, time.minute, 0, 0);
-      timesOnDay.push(time.decimal);
-      dayTimes.set(dayOffset, timesOnDay);
-      slots.push({
-        postId: platformPosts[placedCount].id,
-        platform,
-        scheduledDate: date.toISOString(),
-      });
-      placedCount += 1;
-    };
-
-    if (totalExisting === 0 || !additiveMode) {
-      // ── Phase A path: midpoint quantile + CDF inversion.
-      //
-      // Used for first-time scheduling and for `additiveMode: false` (e.g.
-      // #178 redistribute). When existing posts are present but additiveMode
-      // is off, they're treated as external collision constraints — the
-      // pre-loaded dayCounts still apply maxPerDay caps via the walk-outward
-      // logic, but the curve target is computed for newPostCount only.
-      const cumulative: number[] = [];
-      let cum = 0;
-      for (const w of curveNormalized) {
-        cum += w;
-        cumulative.push(cum);
-      }
-      for (let i = 0; i < postCount; i++) {
-        const target = (i + 0.5) / postCount;
-        const preferredIdx = cdfInvert(cumulative, target);
-        const dayIdx = findAvailableDayIdx(
-          preferredIdx,
-          validDays,
-          dayCounts,
-          cadence.maxPerDay,
-          curveNormalized,
-        );
-        placeAt(dayIdx);
-      }
-    } else {
-      // ── Phase B: density-aware additive (#84 Phase 2) — greedy deficit fill
-      //
-      // For each new post, pick the valid day with the largest remaining
-      // deficit (= ideal − existing − already-placed-this-run) where cadence
-      // still has room. This produces a combined existing+new distribution
-      // close to what scheduling totalPostCount from scratch would give.
-      const totalPostCount = postCount + totalExisting;
-      const idealPerDay = curveNormalized.map((w) => w * totalPostCount);
-      const remainingDeficit = idealPerDay.map((ideal, idx) =>
-        ideal - (dayCounts.get(validDays[idx]) ?? 0),
-      );
-
-      for (let i = 0; i < postCount; i++) {
-        // Pick the valid day with max remaining deficit AND cadence room.
-        let bestIdx = -1;
-        let bestDef = -Infinity;
-        for (let j = 0; j < validDays.length; j++) {
-          if ((dayCounts.get(validDays[j]) ?? 0) >= cadence.maxPerDay) continue;
-          if (remainingDeficit[j] > bestDef) {
-            bestDef = remainingDeficit[j];
-            bestIdx = j;
-          }
-        }
-        if (bestIdx < 0) {
-          // No room on any valid day — over-allocate via curve-weighted walk
-          // (degraded mode; cadence couldn't fit existing+new).
-          bestIdx = findAvailableDayIdx(
-            0,
-            validDays,
-            dayCounts,
-            cadence.maxPerDay,
-            curveNormalized,
-          );
-        }
-        remainingDeficit[bestIdx] -= 1;
-        placeAt(bestIdx);
-      }
+  // Aggregate placed-per-day (across platforms). In additiveMode, pre-load
+  // with existing counts so deficit reflects only what's still missing.
+  const placedPerDay = new Array<number>(durationDays).fill(0);
+  if (additiveMode) {
+    for (const [, s] of states) {
+      for (const [d, count] of s.dayCounts) placedPerDay[d] += count;
     }
   }
 
-  // Sort by scheduled date
+  // Stable platform ordering for deterministic tie-breaks
+  const platformOrder = [...states.keys()].sort();
+  const platformIndex = new Map(platformOrder.map((p, i) => [p, i] as const));
+
+  // Track per-platform "placed-this-run" count for round-robin tie-break
+  const placedThisRun = new Map<string, number>();
+  for (const p of platformOrder) placedThisRun.set(p, 0);
+
+  // ── 4. Greedy deficit-fill loop ─────────────────────────────────────
+  const totalPostsToPlace = posts.length;
+  let totalPlaced = 0;
+
+  while (totalPlaced < totalPostsToPlace) {
+    let bestPlatform: string | null = null;
+    let bestDay = -1;
+    let bestDeficit = -Infinity;
+    let bestPlacedThisRun = Infinity;
+    let bestPlatformIdx = Infinity;
+
+    for (const platform of platformOrder) {
+      const s = states.get(platform)!;
+      if (s.placedDayOffsets.length >= s.posts.length) continue;
+      const platPlaced = placedThisRun.get(platform)!;
+      const platIdx = platformIndex.get(platform)!;
+
+      for (let d = 0; d < durationDays; d++) {
+        if (!s.activeMask[d]) continue;
+        if ((s.dayCounts.get(d) ?? 0) >= s.cadence.maxPerDay) continue;
+        const deficit = idealPerDay[d] - placedPerDay[d];
+        // Lexicographic tie-break: (deficit desc, placedThisRun asc, day asc, platformIdx asc)
+        if (
+          deficit > bestDeficit ||
+          (deficit === bestDeficit && platPlaced < bestPlacedThisRun) ||
+          (deficit === bestDeficit && platPlaced === bestPlacedThisRun && d < bestDay) ||
+          (deficit === bestDeficit && platPlaced === bestPlacedThisRun && d === bestDay && platIdx < bestPlatformIdx)
+        ) {
+          bestDeficit = deficit;
+          bestPlatform = platform;
+          bestDay = d;
+          bestPlacedThisRun = platPlaced;
+          bestPlatformIdx = platIdx;
+        }
+      }
+    }
+
+    if (bestPlatform === null || bestDay < 0) {
+      // No platform has cap room on any active day — degraded mode.
+      // Find any (platform, day) where the platform still has posts and
+      // the day is active, ignoring maxPerDay (best-effort over-allocation).
+      for (const platform of platformOrder) {
+        const s = states.get(platform)!;
+        if (s.placedDayOffsets.length >= s.posts.length) continue;
+        for (let d = 0; d < durationDays; d++) {
+          if (!s.activeMask[d]) continue;
+          const deficit = idealPerDay[d] - placedPerDay[d];
+          if (deficit > bestDeficit) {
+            bestDeficit = deficit;
+            bestPlatform = platform;
+            bestDay = d;
+          }
+        }
+      }
+      if (bestPlatform === null || bestDay < 0) break; // truly stuck
+    }
+
+    // Place
+    const s = states.get(bestPlatform)!;
+    s.dayCounts.set(bestDay, (s.dayCounts.get(bestDay) ?? 0) + 1);
+    s.placedDayOffsets.push(bestDay);
+    placedPerDay[bestDay] += 1;
+    placedThisRun.set(bestPlatform, placedThisRun.get(bestPlatform)! + 1);
+    totalPlaced += 1;
+  }
+
+  // ── 5. Map sorted day-offsets to sortOrder-ordered posts + pick times ──
+  const slots: ScheduleSlot[] = [];
+  for (const [platform, s] of states) {
+    const sortedDays = [...s.placedDayOffsets].sort((a, b) => a - b);
+    for (let i = 0; i < sortedDays.length && i < s.posts.length; i++) {
+      const dayOffset = sortedDays[i];
+      const date = new Date(startDate);
+      date.setDate(date.getDate() + dayOffset);
+      const timesOnDay = s.dayTimes.get(dayOffset) ?? [];
+      const time = pickTimeWithSpacing(s.cadence, timesOnDay);
+      date.setHours(time.hour, time.minute, 0, 0);
+      timesOnDay.push(time.decimal);
+      s.dayTimes.set(dayOffset, timesOnDay);
+      slots.push({
+        postId: s.posts[i].id,
+        platform,
+        scheduledDate: date.toISOString(),
+      });
+    }
+  }
+
+  // Sort by scheduled date for stable output
   slots.sort((a, b) => new Date(a.scheduledDate).getTime() - new Date(b.scheduledDate).getTime());
 
   return slots;

--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -53,6 +53,19 @@ export interface ScheduleInput {
    * via `.split("T")[0]`). Inner value: number of posts already on that day.
    */
   excludedDates?: Map<string, Map<string, number>>;
+  /**
+   * How to interpret existing posts in `excludedDates`.
+   *
+   * - `true` (additive — same-campaign expansion, #84 Phase 2): existing posts
+   *   contribute to the curve's total target distribution. New posts use
+   *   greedy deficit-fill so the combined existing+new shape approximates
+   *   scheduling totalPostCount from scratch.
+   * - `false` (default — external collisions, #178 redistribute): existing
+   *   posts are treated as pure collision constraints (other campaigns'
+   *   posts, reserved slots). They count toward `maxPerDay` caps but do
+   *   NOT shape the curve. Phase A midpoint-quantile sampling is used.
+   */
+  additiveMode?: boolean;
 }
 
 // ── Resolved cadence (internal) ───────────────────────────────────────
@@ -246,7 +259,15 @@ function findAvailableDayIdx(
  * 4. Assign specific times using organic variation
  */
 export function schedulePostsAlgorithm(input: ScheduleInput): ScheduleSlot[] {
-  const { posts, startDate, durationDays, bias, cadence: cadenceConfig, excludedDates } = input;
+  const {
+    posts,
+    startDate,
+    durationDays,
+    bias,
+    cadence: cadenceConfig,
+    excludedDates,
+    additiveMode = false,
+  } = input;
 
   if (posts.length === 0 || durationDays <= 0) return [];
 
@@ -325,8 +346,14 @@ export function schedulePostsAlgorithm(input: ScheduleInput): ScheduleSlot[] {
       placedCount += 1;
     };
 
-    if (totalExisting === 0) {
-      // ── Phase A: first-time scheduling — midpoint quantile + CDF inversion
+    if (totalExisting === 0 || !additiveMode) {
+      // ── Phase A path: midpoint quantile + CDF inversion.
+      //
+      // Used for first-time scheduling and for `additiveMode: false` (e.g.
+      // #178 redistribute). When existing posts are present but additiveMode
+      // is off, they're treated as external collision constraints — the
+      // pre-loaded dayCounts still apply maxPerDay caps via the walk-outward
+      // logic, but the curve target is computed for newPostCount only.
       const cumulative: number[] = [];
       let cum = 0;
       for (const w of curveNormalized) {


### PR DESCRIPTION
## Summary

Phase D of the scheduling-trust epic ([#178](https://github.com/JuergenB/polywiz-app/issues/178)) — **Phases 1 (backend) + 2 (UI)**. Re-spreads a campaign's surviving posts across a new date window via a dialog in the campaign detail's overflow menu, with brand-wide other-campaign posts as collision constraints.

## Stacked on top of [#212](https://github.com/JuergenB/polywiz-app/pull/212)

This PR targets `fix/scheduling-additive` (Phase B's branch). Merge order:
1. [#211](https://github.com/JuergenB/polywiz-app/pull/211) (Phase A) → main
2. [#212](https://github.com/JuergenB/polywiz-app/pull/212) (Phase B) → main
3. This PR auto-retargets to main → merge

## What landed

### Backend (Phase 1)
- ✅ `POST /api/campaigns/[id]/redistribute` accepts `{ startDate, endDate, distributionBias, apply }`
- ✅ `apply: false` returns mapping + stats without writing
- ✅ `apply: true` writes Airtable + fires Zernio + lnk.bio per Scheduled post
- ✅ Cross-campaign collision avoidance (brand-wide Scheduled+Published as `excludedDates`)
- ✅ This-campaign Pending posts with a date treated as reservations
- ✅ Per-platform cadence respected, `Sort Order` preserved
- ✅ Campaign `Start Date` / `Duration Days` / `Distribution Bias` updated on apply
- ✅ Zernio `updatePost` includes `scheduledFor` (the documented trap)
- ✅ lnk.bio delete-then-recreate via existing `applyPostChanges`

### UI (Phase 2)
- ✅ "Redistribute…" item in campaign detail's overflow menu (gated on Approved+Scheduled count > 0; disabled for archived)
- ✅ `RedistributeDialog` with date pickers, bias select, defaults pulled from current campaign settings
- ✅ Preview button → renders proposed timeline as a second `CampaignTimeline` strip below the inputs (reuses the existing component with synthetic posts — same colors, same dot rendering)
- ✅ Stats row: posts to re-place, brand-wide collisions respected, Pending reservations, duration, bias
- ✅ Confirm button labeled with the count
- ✅ Editing inputs after preview clears the preview state (avoids stale-mapping confirms)

### Algorithm: explicit `additiveMode` flag
While building, I realized Phase B's auto-trigger (deficit-fill activates whenever `totalExisting > 0`) would misclassify redistribute. Brand-wide externals shouldn't reshape THIS campaign's curve — they're collision constraints, not curve contributors. Made it explicit:

| Mode | Used by | Behavior |
|---|---|---|
| `additiveMode: true` | `/schedule` (within-campaign add-more) | Phase B greedy deficit-fill |
| `additiveMode: false` (default) | `/redistribute` and any first-time call | Phase A midpoint, externals are collision-only |

`/schedule` opts in explicitly. PR [#212](https://github.com/JuergenB/polywiz-app/pull/212)'s tests updated to set the flag.

## Visual verification

First-render verification on a real campaign (The Intersect Issue 75, 19 Approved+Scheduled posts):

**Overflow menu — new "Redistribute…" item:**
![menu](https://njhagrdezivhku5m.public.blob.vercel-storage.com/scheduling-fix-178/menu.png)

**Dialog input state — defaults pulled from campaign:**
![input](https://njhagrdezivhku5m.public.blob.vercel-storage.com/scheduling-fix-178/dialog-input.png)

**Dialog preview state — proposed timeline + stats:**
![preview](https://njhagrdezivhku5m.public.blob.vercel-storage.com/scheduling-fix-178/dialog-preview.png)

**Verifiable from screenshots:**
- Menu item renders with correct count badge (19)
- Dialog inputs render with correct defaults (campaign Start Date + Duration Days + Distribution Bias)
- Preview button triggers the route correctly; stats render (19 to re-place, 86 brand-wide collisions, 14 days, Front-loaded)
- Timeline strip renders proposed mapping in front-loaded shape

**Not verifiable — needs your eyes:**
- Some visual redundancy — the embedded `CampaignTimeline` shows its own "CAMPAIGN TIMELINE" header inside the dialog's "PROPOSED TIMELINE" section. Could trim the inner header for the in-dialog mode (small polish).
- Whether the `sm:max-w-3xl` dialog width feels right.
- The small back-edge cluster (May 13) in the preview shape is algorithm-driven from cadence pressure with 86 brand-wide collisions, not a bug — but worth a sanity check on whether it matches your expectation.

## Test plan

- [x] 28 vitest tests pass (18 Phase A + 7 Phase B + 3 Phase D)
- [x] `npx tsc --noEmit` clean across backend + UI
- [x] eslint clean on touched files
- [x] Visual first-render verified via Playwright (clip ≤1500px, deviceScaleFactor=1)
- [ ] End-to-end smoke test of `apply: true` against a real campaign — pending your call (would mutate live data; recommend doing this on a test campaign first, or wait until merge to main + production smoke test)

## Honest disclosures (carried over)

1. **Cadence-overflow is silent-pack-as-best-can.** Spec [open question #4](https://github.com/JuergenB/polywiz-app/issues/178); could surface a "M posts couldn't fit cadence cleanly" warning in the dialog as Phase 3 polish.
2. **Partial-failure UX uses the proposed default** (Airtable-first, fire-and-forget downstream, summary in toast). Spec [open question #1](https://github.com/JuergenB/polywiz-app/issues/178) is still TBD if you want different.
3. **Concurrency: documented as "don't do that".** Two simultaneous redistributes for the same campaign would race; not addressed for MVP per spec.
4. **No live-apply smoke test yet.** UI verified first-render only; happy to do a live test on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)