### PR TITLE
feat(campaigns): inline-edit campaign title on detail page

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ See [GETTING_STARTED.md](GETTING_STARTED.md) for the full development guide.
 - [x] **Phase II:** Campaign image library — scraped images surfaced as clickable thumbnails when adding images to posts
 - [x] **Phase II:** Image caption extraction — figcaption / wp-caption parsing flows through to post media captions
 - [x] **Phase II:** Options expander state persists across campaigns (cookie-backed open/closed preference)
+- [x] **Phase II:** Inline-rename campaign title on detail page (click h1, save to Airtable, Quick Post auto-rename respects user edits) (#221)
 - [x] **Phase III:** Cover slide designer — band-based layout engine (Satori + Sharp), Airtable-driven templates, AI text generation, eyedropper color picker
 - [x] **Phase III:** Card designer with URL-based tracking and slide exclusion
 - [x] **Phase III:** Multi-image carousel handling matched to platform capability — LinkedIn PDF assembly; non-carousel platforms (Facebook, Pinterest, etc.) fall back to first image with honest UI messaging

--- a/src/app/api/campaigns/[id]/generate/route.ts
+++ b/src/app/api/campaigns/[id]/generate/route.ts
@@ -628,7 +628,10 @@ export async function POST(
 
         // Store scraped data on campaign record (skip status change in additive mode)
         // Also set og:image as campaign image if none exists
-        // For Quick Posts, also save the scraped title as description and update the name
+        // For Quick Posts, also save the scraped title as description and update the name —
+        // BUT only if the user hasn't manually renamed the campaign away from the
+        // "Quick Post:" prefix (issue #221). Re-check at the conditional moment so
+        // an inline-rename made between scrape start and this write is respected.
         const ogImageUrl = blogData.ogImage || blogData.heroImage?.url || "";
         const isQuickPostCampaign = fields.Name?.startsWith("Quick Post:");
 
@@ -648,13 +651,24 @@ export async function POST(
             ? await mirrorRemoteImageToBlob(ogImageUrl, "campaigns", campaignId)
             : "";
 
+        // Re-check the latest Name at the conditional moment (issue #221).
+        // The local `fields` snapshot was loaded at the top of generate; if the
+        // user inline-renamed the campaign during the scrape, that rename must
+        // not be clobbered. Refetch + skip the auto-rename if the user has
+        // dropped the "Quick Post:" prefix.
+        const latestCampaignForName = await getRecord<CampaignFields>("Campaigns", campaignId);
+        const latestNameIsQuickPost =
+          latestCampaignForName.fields.Name?.startsWith("Quick Post:") ?? false;
+        const shouldAutoRenameQuickPost =
+          isQuickPostCampaign && latestNameIsQuickPost && !!blogData.title;
+
         await updateRecord("Campaigns", campaignId, {
           ...(isAdditive ? {} : { Status: "Generating" }),
           "Scraped Content": blogData.content.slice(0, 10000),
           "Scraped Images": JSON.stringify(blogData.images),
           ...(mirroredOgImageUrl ? { "Image URL": mirroredOgImageUrl } : {}),
           ...(!fields.Description && blogData.title ? { Description: blogData.title } : {}),
-          ...(isQuickPostCampaign && blogData.title ? { Name: `Quick Post: ${blogData.title}` } : {}),
+          ...(shouldAutoRenameQuickPost ? { Name: `Quick Post: ${blogData.title}` } : {}),
           // Artist Profile: set descriptive campaign name and store artist handle
           ...(isArtistProfile && artistCampaignName ? { Name: artistCampaignName } : {}),
           ...(isArtistProfile && artistMeta?.instagramHandle ? { "Artist Handle": artistMeta.instagramHandle } : {}),

--- a/src/app/api/campaigns/[id]/route.ts
+++ b/src/app/api/campaigns/[id]/route.ts
@@ -199,8 +199,22 @@ export async function PATCH(
 
     const body = await request.json();
 
+    // Validate campaign name: trim whitespace, reject empty after trim.
+    // Done here (before the allowlist loop) so the trimmed value is what
+    // gets persisted to Airtable.
+    if (body.name !== undefined) {
+      if (typeof body.name !== "string" || body.name.trim() === "") {
+        return NextResponse.json(
+          { error: "Campaign name cannot be empty" },
+          { status: 400 }
+        );
+      }
+      body.name = body.name.trim();
+    }
+
     // Only allow updates to editable fields
     const allowedFields: Record<string, string> = {
+      name: "Name",
       url: "URL",
       type: "Type",
       durationDays: "Duration Days",

--- a/src/app/dashboard/campaigns/[id]/page.tsx
+++ b/src/app/dashboard/campaigns/[id]/page.tsx
@@ -222,6 +222,10 @@ export default function CampaignDetailPage() {
   const [genVoiceIntensity, setGenVoiceIntensity] = useState<number>(50);
   const [genVoiceInitialized, setGenVoiceInitialized] = useState(false);
   const [settingsUnsaved, setSettingsUnsaved] = useState(false);
+  // Inline-rename state for the campaign h1 (issue #221).
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [nameDraft, setNameDraft] = useState("");
+  const [isSavingName, setIsSavingName] = useState(false);
   // Settings used to be a tab; it's now a right-side Sheet drawer (Slice 1
   // of the campaign-detail UX redesign). Backward-compat: ?tab=settings in
   // the URL still opens the Sheet, and the existing #delete-campaign-section
@@ -918,6 +922,47 @@ export default function CampaignDetailPage() {
   const isQuickPost = campaign.name?.startsWith("Quick Post:");
   const backHref = isQuickPost ? "/dashboard/quick-post" : "/dashboard/campaigns";
 
+  // Inline-rename handlers (issue #221).
+  // Click h1 → input pre-filled with current name; Enter/blur saves;
+  // Esc cancels; empty/whitespace or unchanged → no-op restore.
+  const startNameEdit = () => {
+    setNameDraft(campaign.name || "");
+    setIsEditingName(true);
+  };
+  const cancelNameEdit = () => {
+    setIsEditingName(false);
+    setNameDraft("");
+  };
+  const saveNameEdit = async () => {
+    const trimmed = nameDraft.trim();
+    if (!trimmed || trimmed === campaign.name) {
+      cancelNameEdit();
+      return;
+    }
+    setIsSavingName(true);
+    try {
+      const res = await fetch(`/api/campaigns/${campaign.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: trimmed }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to rename campaign");
+      }
+      toast.success("Campaign renamed");
+      setIsEditingName(false);
+      // Refetch the detail-page campaign + the campaigns list so the
+      // dashboard widget and calendar combobox pick up the new name.
+      queryClient.invalidateQueries({ queryKey: ["campaign", campaignId] });
+      queryClient.invalidateQueries({ queryKey: ["campaigns"] });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to rename campaign");
+    } finally {
+      setIsSavingName(false);
+    }
+  };
+
   // ── Render ──────────────────────────────────────────────────────────
 
   return (
@@ -929,7 +974,35 @@ export default function CampaignDetailPage() {
             <ArrowLeft className="h-4 w-4" />
           </Link>
         </Button>
-        <h1 className="text-xl font-bold flex-1 break-words">{displayName}</h1>
+        {isEditingName ? (
+          <Input
+            type="text"
+            value={nameDraft}
+            onChange={(e) => setNameDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                saveNameEdit();
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                cancelNameEdit();
+              }
+            }}
+            onBlur={saveNameEdit}
+            disabled={isSavingName}
+            autoFocus
+            aria-label="Campaign name"
+            className="text-xl font-bold flex-1 h-auto py-1 px-2"
+          />
+        ) : (
+          <h1
+            className="text-xl font-bold flex-1 break-words cursor-pointer rounded px-2 py-1 -mx-2 -my-1 hover:bg-muted/60 transition-colors"
+            onClick={startNameEdit}
+            title="Click to rename"
+          >
+            {displayName}
+          </h1>
+        )}
         <CampaignHeaderActions
           campaign={campaign}
           posts={posts}


### PR DESCRIPTION
Closes [#221](https://github.com/JuergenB/polywiz-app/issues/221).

## What

Click the campaign h1 on `/dashboard/campaigns/[id]` to rename inline. Saves to Airtable via the existing PATCH endpoint and propagates to the dashboard widget and calendar combobox via `invalidateQueries`.

## How it works

- **Click** the title → swap `<h1>` for an `<Input>` pre-filled with the current name (autofocused).
- **Enter** or **blur** → PATCH `/api/campaigns/[id]` with `{ name: trimmed }`, toast success, invalidate the campaign + campaigns list queries.
- **Esc** → cancel without saving.
- **Empty / whitespace / unchanged** → no-op restore.
- **Validation server-side**: empty after trim → 400 `{ error: "Campaign name cannot be empty" }`.

## Quick Post collision — respected

Quick Post campaigns auto-rename themselves to `"Quick Post: <scraped title>"` during generation. If a user inline-renames a Quick Post (dropping the `"Quick Post:"` prefix), regeneration must not clobber the edit.

The fix re-fetches the latest campaign Name right before the auto-rename conditional, not from the snapshot loaded at the top of the generate handler. This also covers the race where the rename happens *during* the scrape.

## Files

| File | LOC | Change |
|---|---|---|
| `src/app/api/campaigns/[id]/route.ts` | +14 | `name` added to PATCH allowlist; trim + non-empty validation |
| `src/app/dashboard/campaigns/[id]/page.tsx` | +73 | Inline-edit state, handlers, h1↔Input swap |
| `src/app/api/campaigns/[id]/generate/route.ts` | +15 / -1 | Refetch latest Name before Quick Post auto-rename |

## Verified

- `npx tsc --noEmit` → clean
- Code review against existing patterns (sonner toast, TanStack Query, shadcn Input — all already in this file)

## Not verified — needs manual smoke test

- Click → input swap visual fidelity (font weight/size match h1)
- Save → Airtable round-trip + dashboard widget reflects new name
- Esc cancels without flicker
- Quick Post rename → regenerate → user edit preserved

## Out of scope (intentional)

- Renaming from the campaign list cards — separate iteration
- Backfilling Short.io slugs (baked at generate time, acceptable for published links)
- Re-running cover slide AI generation after rename (only affects future regenerations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)