### PR TITLE
feat(scripts): backfill markdown sanitization for Pending+Approved posts

### DIFF
--- a/scripts/sanitize-post-markdown.mjs
+++ b/scripts/sanitize-post-markdown.mjs
@@ -22,6 +22,7 @@
  *   --dry-run           Print what would change but do not PATCH Airtable.
  *   --limit <n>         Stop after processing n posts (useful for testing).
  *   --post-id <id>      Process only one post by record ID (for spot-checking).
+ *   --campaign-id <id>  Restrict to posts linked to a single campaign (for staged rollout).
  *   --help              Show this help.
  *
  * Requires: AIRTABLE_API_KEY in .env.local
@@ -76,7 +77,14 @@ function runSelfCheck() {
 
 // ── Args ────────────────────────────────────────────────────────────────
 function parseArgs(argv) {
-  const args = { status: "Pending,Approved", dryRun: false, limit: null, postId: null, help: false };
+  const args = {
+    status: "Pending,Approved",
+    dryRun: false,
+    limit: null,
+    postId: null,
+    campaignId: null,
+    help: false,
+  };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--help" || a === "-h") args.help = true;
@@ -84,6 +92,7 @@ function parseArgs(argv) {
     else if (a === "--status") args.status = argv[++i];
     else if (a === "--limit") args.limit = parseInt(argv[++i], 10);
     else if (a === "--post-id") args.postId = argv[++i];
+    else if (a === "--campaign-id") args.campaignId = argv[++i];
     else {
       console.error(`Unknown arg: ${a}`);
       process.exit(1);
@@ -103,12 +112,15 @@ Options:
   --dry-run           Print what would change but do not PATCH Airtable.
   --limit <n>         Stop after processing n posts (useful for testing).
   --post-id <id>      Process only one post by record ID (for spot-checking).
+  --campaign-id <id>  Restrict to posts linked to a single campaign (for staged rollout).
   --help              Show this help.
 
 Examples:
   node scripts/sanitize-post-markdown.mjs --dry-run
   node scripts/sanitize-post-markdown.mjs --dry-run --limit 3
   node scripts/sanitize-post-markdown.mjs --post-id reccoOS13ot0rppmQ
+  node scripts/sanitize-post-markdown.mjs --dry-run --campaign-id rec9mWm5hFz3dPklc
+  node scripts/sanitize-post-markdown.mjs --campaign-id rec9mWm5hFz3dPklc
   node scripts/sanitize-post-markdown.mjs
 `;
 
@@ -208,12 +220,15 @@ function buildFilterFormula(statuses) {
   return `OR(${clauses})`;
 }
 
-async function* iteratePosts({ statuses, postId, token }) {
+async function* iteratePosts({ statuses, postId, campaignId, token }) {
   if (postId) {
     const data = await airtableGet(`/${POSTS_TABLE_ID}/${postId}`, token);
     yield data;
     return;
   }
+  // Note: Airtable's ARRAYJOIN({Campaign}) returns the campaigns' PRIMARY FIELD
+  // values (display names), not record IDs — so we can't filter by linked record
+  // ID server-side. We filter campaigns client-side after fetching by status.
   let offset;
   do {
     const params = new URLSearchParams();
@@ -221,9 +236,14 @@ async function* iteratePosts({ statuses, postId, token }) {
     params.set("filterByFormula", buildFilterFormula(statuses));
     params.append("fields[]", "Content");
     params.append("fields[]", "Status");
+    params.append("fields[]", "Campaign");
     if (offset) params.set("offset", offset);
     const data = await airtableGet(`/${POSTS_TABLE_ID}?${params.toString()}`, token);
     for (const record of data.records ?? []) {
+      if (campaignId) {
+        const linked = record.fields?.Campaign ?? [];
+        if (!linked.includes(campaignId)) continue;
+      }
       yield record;
     }
     offset = data.offset;
@@ -264,6 +284,7 @@ async function main() {
   }
   console.log(`Status filter: ${statuses.join(", ")}`);
   if (args.postId) console.log(`Single post: ${args.postId}`);
+  if (args.campaignId) console.log(`Campaign filter: ${args.campaignId}`);
   if (args.limit) console.log(`Limit: ${args.limit}`);
   console.log("");
 
@@ -273,7 +294,12 @@ async function main() {
   let errors = 0;
 
   try {
-    for await (const record of iteratePosts({ statuses, postId: args.postId, token })) {
+    for await (const record of iteratePosts({
+      statuses,
+      postId: args.postId,
+      campaignId: args.campaignId,
+      token,
+    })) {
       if (args.limit && processed >= args.limit) break;
       processed++;
 

--- a/scripts/sanitize-post-markdown.mjs
+++ b/scripts/sanitize-post-markdown.mjs
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+/**
+ * Backfill markdown sanitization for existing post Content.
+ *
+ * Strips italic/bold markdown (`_x_`, `*x*`, `__x__`, `**x**`) and replaces
+ * with curly quotes (“ ”) — see issue #222.
+ *
+ * Scope (locked):
+ *   - Statuses: Pending, Approved (default; --status overridable within these two)
+ *   - Field: Content only
+ *   - Scheduled is deferred to #224 (requires Zernio updatePost coordination)
+ *   - Published / Failed are terminal — never touched
+ *
+ * Usage:
+ *   node scripts/sanitize-post-markdown.mjs [options]
+ *
+ * Options:
+ *   --status <list>     Comma-separated status filter (default: "Pending,Approved")
+ *                       Allowed values: Pending, Approved
+ *                       Scheduled/Published/Failed are explicitly rejected for safety;
+ *                       see issue #224 for the Scheduled-posts plan.
+ *   --dry-run           Print what would change but do not PATCH Airtable.
+ *   --limit <n>         Stop after processing n posts (useful for testing).
+ *   --post-id <id>      Process only one post by record ID (for spot-checking).
+ *   --help              Show this help.
+ *
+ * Requires: AIRTABLE_API_KEY in .env.local
+ */
+
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+// ── Sanitizer ───────────────────────────────────────────────────────────
+// Markdown italic/bold → curly quotes.
+// CANONICAL SOURCE: src/lib/text-sanitizer.ts (lands in PR for issue #222).
+// This script duplicates the regex deliberately to avoid TS↔mjs interop;
+// if you change one, change both.
+function stripMarkdownFormatting(text) {
+  if (!text) return text;
+  return text
+    .replace(/\*\*([^*\n]+)\*\*/g, "“$1”")
+    .replace(/(?<!\w)__([^_\n]+)__(?!\w)/g, "“$1”")
+    .replace(/(?<!\w)_([^_\n]+)_(?!\w)/g, "“$1”")
+    .replace(/(?<!\w)\*([^*\n]+)\*(?!\w)/g, "“$1”");
+}
+
+// ── Self-check fixtures ─────────────────────────────────────────────────
+function runSelfCheck() {
+  const cases = [
+    {
+      input: "Wesley Goatley's _The Harbinger_ is about",
+      expected: "Wesley Goatley's “The Harbinger” is about",
+    },
+    { input: "**bold** thing", expected: "“bold” thing" },
+    { input: "my_variable_name", expected: "my_variable_name" },
+    { input: "#some_tag", expected: "#some_tag" },
+    { input: "*emphasized*", expected: "“emphasized”" },
+    { input: "__strong__", expected: "“strong”" },
+    { input: "", expected: "" },
+  ];
+  let failed = 0;
+  for (const { input, expected } of cases) {
+    const actual = stripMarkdownFormatting(input);
+    if (actual !== expected) {
+      console.error(
+        `Self-check FAILED:\n  input:    ${JSON.stringify(input)}\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(actual)}`,
+      );
+      failed++;
+    }
+  }
+  if (failed > 0) {
+    console.error(`\n${failed} self-check fixture(s) failed. Aborting before any Airtable I/O.`);
+    process.exit(1);
+  }
+}
+
+// ── Args ────────────────────────────────────────────────────────────────
+function parseArgs(argv) {
+  const args = { status: "Pending,Approved", dryRun: false, limit: null, postId: null, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") args.help = true;
+    else if (a === "--dry-run") args.dryRun = true;
+    else if (a === "--status") args.status = argv[++i];
+    else if (a === "--limit") args.limit = parseInt(argv[++i], 10);
+    else if (a === "--post-id") args.postId = argv[++i];
+    else {
+      console.error(`Unknown arg: ${a}`);
+      process.exit(1);
+    }
+  }
+  return args;
+}
+
+const HELP_TEXT = `Usage:
+  node scripts/sanitize-post-markdown.mjs [options]
+
+Options:
+  --status <list>     Comma-separated status filter (default: "Pending,Approved")
+                      Allowed values: Pending, Approved
+                      Scheduled/Published/Failed are explicitly rejected for safety;
+                      see issue #224 for the Scheduled-posts plan.
+  --dry-run           Print what would change but do not PATCH Airtable.
+  --limit <n>         Stop after processing n posts (useful for testing).
+  --post-id <id>      Process only one post by record ID (for spot-checking).
+  --help              Show this help.
+
+Examples:
+  node scripts/sanitize-post-markdown.mjs --dry-run
+  node scripts/sanitize-post-markdown.mjs --dry-run --limit 3
+  node scripts/sanitize-post-markdown.mjs --post-id reccoOS13ot0rppmQ
+  node scripts/sanitize-post-markdown.mjs
+`;
+
+const ALLOWED_STATUSES = new Set(["Pending", "Approved"]);
+const REJECTED_STATUSES = new Set(["Scheduled", "Published", "Failed"]);
+
+function validateStatuses(statusArg) {
+  const list = statusArg
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (list.length === 0) {
+    console.error("--status must include at least one value (Pending, Approved).");
+    process.exit(1);
+  }
+  for (const s of list) {
+    if (REJECTED_STATUSES.has(s)) {
+      console.error(
+        `Status "${s}" is not allowed for this script.\n` +
+          `  - Scheduled posts must be coordinated with Zernio updatePost — tracked in issue #224.\n` +
+          `  - Published and Failed are terminal and will not be modified.\n` +
+          `Allowed values: Pending, Approved.`,
+      );
+      process.exit(1);
+    }
+    if (!ALLOWED_STATUSES.has(s)) {
+      console.error(`Unknown status "${s}". Allowed values: Pending, Approved.`);
+      process.exit(1);
+    }
+  }
+  return list;
+}
+
+// ── Env ─────────────────────────────────────────────────────────────────
+function loadEnv() {
+  const envPath = resolve(process.cwd(), ".env.local");
+  let envText;
+  try {
+    envText = readFileSync(envPath, "utf-8");
+  } catch (err) {
+    console.error(`Could not read .env.local at ${envPath}: ${err.message}`);
+    process.exit(1);
+  }
+  for (const line of envText.split("\n")) {
+    const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (match) {
+      const key = match[1];
+      let value = match[2];
+      // Strip surrounding quotes if present
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (!process.env[key]) process.env[key] = value;
+    }
+  }
+}
+
+// ── Airtable ────────────────────────────────────────────────────────────
+const BASE_ID = "app5FPCG06huzh7hX";
+const POSTS_TABLE_ID = "tblyUEPOJXxpQDZNL";
+
+function airtableUrl(path) {
+  return `https://api.airtable.com/v0/${BASE_ID}${path}`;
+}
+
+async function airtableGet(path, token) {
+  const res = await fetch(airtableUrl(path), {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Airtable GET ${path}: ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function airtablePatch(recordId, fields, token) {
+  const res = await fetch(airtableUrl(`/${POSTS_TABLE_ID}/${recordId}`), {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ fields }),
+  });
+  if (!res.ok) {
+    throw new Error(`Airtable PATCH /${POSTS_TABLE_ID}/${recordId}: ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+function buildFilterFormula(statuses) {
+  if (statuses.length === 1) return `Status='${statuses[0]}'`;
+  const clauses = statuses.map((s) => `Status='${s}'`).join(",");
+  return `OR(${clauses})`;
+}
+
+async function* iteratePosts({ statuses, postId, token }) {
+  if (postId) {
+    const data = await airtableGet(`/${POSTS_TABLE_ID}/${postId}`, token);
+    yield data;
+    return;
+  }
+  let offset;
+  do {
+    const params = new URLSearchParams();
+    params.set("pageSize", "100");
+    params.set("filterByFormula", buildFilterFormula(statuses));
+    params.append("fields[]", "Content");
+    params.append("fields[]", "Status");
+    if (offset) params.set("offset", offset);
+    const data = await airtableGet(`/${POSTS_TABLE_ID}?${params.toString()}`, token);
+    for (const record of data.records ?? []) {
+      yield record;
+    }
+    offset = data.offset;
+  } while (offset);
+}
+
+// ── Utility ─────────────────────────────────────────────────────────────
+function truncate(s, n = 200) {
+  if (!s) return s;
+  return s.length > n ? s.slice(0, n) + "…" : s;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── Main ────────────────────────────────────────────────────────────────
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(HELP_TEXT);
+    process.exit(0);
+  }
+
+  // Validate status arg (rejects Scheduled/Published/Failed)
+  const statuses = validateStatuses(args.status);
+
+  // Self-check fixtures BEFORE any I/O
+  runSelfCheck();
+
+  loadEnv();
+  const token = process.env.AIRTABLE_API_KEY;
+  if (!token) {
+    console.error("AIRTABLE_API_KEY missing from .env.local");
+    process.exit(1);
+  }
+
+  if (args.dryRun) {
+    console.log("DRY RUN — no Airtable writes will be made.\n");
+  }
+  console.log(`Status filter: ${statuses.join(", ")}`);
+  if (args.postId) console.log(`Single post: ${args.postId}`);
+  if (args.limit) console.log(`Limit: ${args.limit}`);
+  console.log("");
+
+  let processed = 0;
+  let changed = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  try {
+    for await (const record of iteratePosts({ statuses, postId: args.postId, token })) {
+      if (args.limit && processed >= args.limit) break;
+      processed++;
+
+      const status = record.fields?.Status;
+      // Defense-in-depth: if a single-post lookup returned a record outside
+      // the allowed statuses, refuse to touch it.
+      if (args.postId && status && REJECTED_STATUSES.has(status)) {
+        console.error(
+          `Refusing to process record ${record.id} with Status="${status}". ` +
+            `Scheduled is deferred to issue #224; Published/Failed are terminal.`,
+        );
+        errors++;
+        continue;
+      }
+      if (args.postId && status && !ALLOWED_STATUSES.has(status)) {
+        console.error(
+          `Skipping record ${record.id} with Status="${status}" (not in allowed set Pending/Approved).`,
+        );
+        skipped++;
+        continue;
+      }
+
+      const before = record.fields?.Content ?? "";
+      const after = stripMarkdownFormatting(before);
+
+      if (before === after) {
+        skipped++;
+        continue;
+      }
+
+      console.log(
+        JSON.stringify(
+          {
+            recordId: record.id,
+            status: status ?? null,
+            before: truncate(before),
+            after: truncate(after),
+          },
+          null,
+          2,
+        ),
+      );
+
+      if (args.dryRun) {
+        changed++;
+        continue;
+      }
+
+      try {
+        await airtablePatch(record.id, { Content: after }, token);
+        changed++;
+        // Pace at ~5 req/sec to stay under Airtable's 5/sec/base rate limit.
+        await sleep(200);
+      } catch (err) {
+        console.error(`PATCH failed for ${record.id}: ${err.message}`);
+        errors++;
+      }
+    }
+  } catch (err) {
+    console.error(`Fatal: ${err.message}`);
+    errors++;
+  }
+
+  console.log("\n--- Summary ---");
+  console.log(`processed: ${processed}`);
+  console.log(`changed:   ${changed}`);
+  console.log(`skipped:   ${skipped}`);
+  console.log(`errors:    ${errors}`);
+
+  process.exit(errors > 0 ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
## Summary

Backfill script to retroactively strip markdown italic/bold from existing post Content. Companion to the forward fix in `feat/strip-post-markdown` (parallel branch by another subagent), which adds the canonical sanitizer in `src/lib/text-sanitizer.ts` and applies it in route handlers + prompts.

This PR is **script-only** — no `src/`, no route handlers, no prompts.

Refs [#222](https://github.com/JuergenB/polywiz-app/issues/222).

## Scope (locked per user decision)

- **Statuses processed:** `Pending` and `Approved` only
- **Field touched:** `Content` only
- **Skipped:** `Scheduled` (deferred to [#224](https://github.com/JuergenB/polywiz-app/issues/224) — requires coordinated Zernio `updatePost`), `Published` and `Failed` (terminal)
- **Format:** italic + bold markdown (`_x_`, `*x*`, `__x__`, `**x**`) → curly quotes (`“ ”`)

The CLI explicitly rejects `--status Scheduled|Published|Failed` with a pointer to [#224](https://github.com/JuergenB/polywiz-app/issues/224). A `--post-id` lookup also refuses to PATCH a record outside the allowed status set (defense-in-depth).

## CLI surface

```
Usage:
  node scripts/sanitize-post-markdown.mjs [options]

Options:
  --status <list>     Comma-separated status filter (default: "Pending,Approved")
                      Allowed values: Pending, Approved
                      Scheduled/Published/Failed are explicitly rejected for safety;
                      see issue #224 for the Scheduled-posts plan.
  --dry-run           Print what would change but do not PATCH Airtable.
  --limit <n>         Stop after processing n posts (useful for testing).
  --post-id <id>      Process only one post by record ID (for spot-checking).
  --help              Show this help.
```

## Sanitizer

Inlined regex in the script (Node `.mjs`, no TS interop). The top-of-file comment points to `src/lib/text-sanitizer.ts` (the canonical TS module landing in the forward-fix PR) so a future cleanup pass can DRY them up if desired.

```js
function stripMarkdownFormatting(text) {
  if (!text) return text;
  return text
    .replace(/\*\*([^*\n]+)\*\*/g, "“$1”")
    .replace(/(?<!\w)__([^_\n]+)__(?!\w)/g, "“$1”")
    .replace(/(?<!\w)_([^_\n]+)_(?!\w)/g, "“$1”")
    .replace(/(?<!\w)\*([^*\n]+)\*(?!\w)/g, "“$1”");
}
```

The negative lookbehind/lookahead protects `my_variable_name` (snake_case) and `#some_tag` (hashtags). Sanitizer is a fixed point on already-clean text — running twice is a no-op.

## Self-check fixtures

Run before any Airtable I/O — script aborts with exit 1 if any fail:

| Input | Expected |
|---|---|
| `Wesley Goatley's _The Harbinger_ is about` | `Wesley Goatley's “The Harbinger” is about` |
| `**bold** thing` | `“bold” thing` |
| `my_variable_name` | `my_variable_name` (unchanged) |
| `#some_tag` | `#some_tag` (unchanged) |
| `*emphasized*` | `“emphasized”` |
| `__strong__` | `“strong”` |
| `` (empty) | `` (empty — null-safe) |

## Verification done in this PR

- `--help` prints usage and exits 0
- `--status Scheduled` / `--status Published` / `--status Failed` / `--status Bogus` each reject with exit 1 and explicit error referencing [#224](https://github.com/JuergenB/polywiz-app/issues/224) where applicable
- `--dry-run --limit 3` reads Airtable successfully and processes 3 records without writing
- Idempotency manually confirmed: running the sanitizer twice on a representative input produces identical output
- No new dependencies (built-in `fs`, native `fetch`)
- No hardcoded credentials — `AIRTABLE_API_KEY` read from `.env.local`
- All identifiers parameterized (script does not embed any specific record ID); the only hardcoded values are the project base/table IDs (`app5FPCG06huzh7hX`, `tblyUEPOJXxpQDZNL`), which are documented in CLAUDE.md.

## Rollout commands (user runs after merge)

The script is **not authorized to run against production yet** — the user will run it themselves after merge.

```bash
# Dry-run first — see candidate set + planned diffs
node scripts/sanitize-post-markdown.mjs --dry-run

# Spot-check one record
node scripts/sanitize-post-markdown.mjs --dry-run --post-id reccoOS13ot0rppmQ
node scripts/sanitize-post-markdown.mjs --post-id reccoOS13ot0rppmQ

# Full run
node scripts/sanitize-post-markdown.mjs
```

The script paces writes at ~5 req/sec (200 ms `setTimeout` between PATCHes) to stay under Airtable's 5/sec/base rate limit.

## Notes

- This PR does **not** close [#222](https://github.com/JuergenB/polywiz-app/issues/222) — the forward-fix PR (parallel branch `feat/strip-post-markdown`) closes the issue itself. This one references with `Refs #222`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
