### PR TITLE
fix(content): strip markdown italic/bold from generated post text (#222)

### DIFF
--- a/src/app/api/campaigns/[id]/generate/route.ts
+++ b/src/app/api/campaigns/[id]/generate/route.ts
@@ -14,6 +14,7 @@ import {
 import { composeSystemPrompt, composeUserPrompt } from "@/lib/prompts/compose-prompt";
 import { createPlatformShortLink } from "@/lib/short-io";
 import { resolvePublicationUrl } from "@/lib/publication-url";
+import { stripMarkdownFormatting } from "@/lib/text-sanitizer";
 import type { PlatformCadenceConfig } from "@/lib/airtable/types";
 import { getEffectiveCadence } from "@/lib/platform-cadence-defaults";
 
@@ -1003,19 +1004,26 @@ export async function POST(
 
         let savedCount = 0;
         for (const post of postsWithLinks) {
+          // Strip markdown italic/bold from generated text — none of the
+          // target platforms render markdown. See #222.
+          const sanitizedContent = stripMarkdownFormatting(post.postText);
+          const sanitizedFirstComment = post.firstComment
+            ? stripMarkdownFormatting(post.firstComment)
+            : "";
+
           const postRecord: Record<string, unknown> = {
             Title: `${blogData.title} — ${post.platform}${post.variant > 1 ? ` (v${post.variant})` : ""}`,
             Campaign: [campaignId],
             Platform: PLATFORM_TO_AIRTABLE[post.platform] || post.platform,
-            Content: post.postText,
+            Content: sanitizedContent,
             "Image URL": post.imageUrl || "",
             "Link URL": publicationUrl,
             "Short URL": post.shortUrl || "",
             "Content Variant": String(post.variant),
             Status: "Pending",
           };
-          if (post.firstComment) {
-            postRecord["First Comment"] = post.firstComment;
+          if (sanitizedFirstComment) {
+            postRecord["First Comment"] = sanitizedFirstComment;
           }
           await createRecord("Posts", postRecord);
           savedCount++;

--- a/src/app/api/posts/[id]/cover-slide-content/route.ts
+++ b/src/app/api/posts/[id]/cover-slide-content/route.ts
@@ -4,6 +4,7 @@ import { getRecord } from "@/lib/airtable/client";
 import { resolveAnthropicConfig } from "@/lib/anthropic";
 import { fetchCoverSlideTemplate } from "@/lib/airtable/cover-slide-templates";
 import { deriveCharBudgets } from "@/lib/cover-slide-renderer";
+import { stripMarkdownFormatting } from "@/lib/text-sanitizer";
 
 interface PostFields {
   Content: string;
@@ -230,11 +231,19 @@ CRITICAL: Respect character limits exactly. Count characters carefully.
       return NextResponse.json({ error: "Failed to parse AI response: " + textContent.text.slice(0, 200) }, { status: 500 });
     }
 
+    // Strip any markdown italics/bolds Claude introduced — these render as
+    // literal characters when Satori paints the cover slide. See #222.
     return NextResponse.json({
       fields: {
-        campaignTypeLabel: (generatedFields.campaignTypeLabel || campaignType || "").slice(0, charBudgets.campaignTypeLabel || 30),
-        headline: (generatedFields.headline || campaignName || "").slice(0, charBudgets.headline || 100),
-        description: (generatedFields.description || "").slice(0, charBudgets.description || 180),
+        campaignTypeLabel: stripMarkdownFormatting(
+          (generatedFields.campaignTypeLabel || campaignType || "").slice(0, charBudgets.campaignTypeLabel || 30)
+        ),
+        headline: stripMarkdownFormatting(
+          (generatedFields.headline || campaignName || "").slice(0, charBudgets.headline || 100)
+        ),
+        description: stripMarkdownFormatting(
+          (generatedFields.description || "").slice(0, charBudgets.description || 180)
+        ),
         // Artist Profile: default to artist's handle; otherwise frontend populates from brand data
         handle: artistHandle ? `@${artistHandle.replace(/^@/, "")}` : "",
       },

--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -3,6 +3,7 @@ import { getRecord, updateRecord, deleteRecord } from "@/lib/airtable/client";
 import { deleteShortLinkIfUnreferenced } from "@/lib/short-link-deletion";
 import { deleteImage, isBlobUrl, mirrorRemoteImageToBlob } from "@/lib/blob-storage";
 import { createBrandClient } from "@/lib/late-api/client";
+import { stripMarkdownFormatting } from "@/lib/text-sanitizer";
 
 /**
  * PATCH /api/posts/[id]
@@ -98,9 +99,13 @@ export async function PATCH(
       }
     }
 
-    // Content
+    // Content — sanitize markdown italics/bolds (curly-quote replacement).
+    // Idempotent: a user typing curly quotes directly is preserved as-is.
+    // See #222.
     if (body.content !== undefined) {
-      fields["Content"] = body.content;
+      fields["Content"] = typeof body.content === "string"
+        ? stripMarkdownFormatting(body.content)
+        : body.content;
     }
 
     // Status changes
@@ -165,9 +170,12 @@ export async function PATCH(
       }
     }
 
-    // First comment (hashtags + engagement hook)
+    // First comment (hashtags + engagement hook) — same markdown sanitation
+    // as Content. See #222.
     if (body.firstComment !== undefined) {
-      fields["First Comment"] = body.firstComment;
+      fields["First Comment"] = typeof body.firstComment === "string"
+        ? stripMarkdownFormatting(body.firstComment)
+        : body.firstComment;
     }
 
     // Collaborators (Instagram collab invites — JSON string array)

--- a/src/lib/__tests__/text-sanitizer.test.ts
+++ b/src/lib/__tests__/text-sanitizer.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Validates stripMarkdownFormatting's curly-quote conversion contract:
+ *   - Italic and bold markdown converted to curly quotes (U+201C / U+201D)
+ *   - snake_case identifiers and hashtags untouched (negative cases)
+ *   - Idempotent on already-sanitized strings
+ *   - Null-safe on empty input
+ *
+ * Related: issue #222.
+ */
+
+import { describe, it, expect } from "vitest";
+import { stripMarkdownFormatting } from "@/lib/text-sanitizer";
+
+describe("stripMarkdownFormatting", () => {
+  it("converts _italic_ to curly quotes", () => {
+    expect(stripMarkdownFormatting("Wesley Goatley's _The Harbinger_ is about what it hears."))
+      .toBe("Wesley Goatley's “The Harbinger” is about what it hears.");
+  });
+
+  it("converts *italic* to curly quotes", () => {
+    expect(stripMarkdownFormatting("This is *emphasized* text"))
+      .toBe("This is “emphasized” text");
+  });
+
+  it("converts **bold** to curly quotes", () => {
+    expect(stripMarkdownFormatting("Read **The Harbinger** today"))
+      .toBe("Read “The Harbinger” today");
+  });
+
+  it("converts __bold__ to curly quotes", () => {
+    expect(stripMarkdownFormatting("Check out __this title__"))
+      .toBe("Check out “this title”");
+  });
+
+  it("handles mixed bold and italic in one string", () => {
+    expect(stripMarkdownFormatting("**Bold** and _italic_ together"))
+      .toBe("“Bold” and “italic” together");
+  });
+
+  it("does NOT touch snake_case identifiers", () => {
+    expect(stripMarkdownFormatting("my_variable_name should stay intact"))
+      .toBe("my_variable_name should stay intact");
+  });
+
+  it("does NOT break hashtags with underscores", () => {
+    expect(stripMarkdownFormatting("Use #some_tag and #my_other_tag"))
+      .toBe("Use #some_tag and #my_other_tag");
+  });
+
+  it("does NOT touch asterisks inside tokens", () => {
+    expect(stripMarkdownFormatting("globs use *.ts patterns"))
+      .toBe("globs use *.ts patterns");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(stripMarkdownFormatting("")).toBe("");
+  });
+
+  it("is null-safe on null/undefined input", () => {
+    // @ts-expect-error — exercising runtime null guard
+    expect(stripMarkdownFormatting(null)).toBe(null);
+    // @ts-expect-error — exercising runtime undefined guard
+    expect(stripMarkdownFormatting(undefined)).toBe(undefined);
+  });
+
+  it("preserves emojis and unicode", () => {
+    expect(stripMarkdownFormatting("_The Harbinger_ is about what it hears. 👂"))
+      .toBe("“The Harbinger” is about what it hears. 👂");
+  });
+
+  it("does not touch markdown links, headings, or inline code", () => {
+    const input = "# Heading\n[text](url) and `code` should stay";
+    expect(stripMarkdownFormatting(input)).toBe(input);
+  });
+
+  it("handles multiple italic spans on the same line", () => {
+    expect(stripMarkdownFormatting("Reading _Book One_ before _Book Two_"))
+      .toBe("Reading “Book One” before “Book Two”");
+  });
+});

--- a/src/lib/prompts/blog-post-generator.ts
+++ b/src/lib/prompts/blog-post-generator.ts
@@ -49,6 +49,8 @@ WRITE LIKE A REAL PERSON:
 - Be opinionated when appropriate
 - Use natural transitions
 
+- Do NOT use markdown formatting (underscores, asterisks) in the post text. None of the target platforms render markdown — formatting characters appear as literal text. For artwork titles, exhibition names, books, and creative works, use curly quotes (e.g. “The Harbinger”). Person names and proper nouns get no special formatting.
+
 </writing_style_requirements>
 
 <platform_tone_guidance>

--- a/src/lib/text-sanitizer.ts
+++ b/src/lib/text-sanitizer.ts
@@ -1,0 +1,26 @@
+/**
+ * Strip markdown italic/bold formatting from social post text and replace
+ * with curly quotes. Used for content destined for platforms that don't
+ * render markdown (Instagram, X, Facebook, Threads, Bluesky, Pinterest,
+ * and even LinkedIn for the underscore variant).
+ *
+ * Scope is intentionally narrow — italic + bold only. Headings (#),
+ * inline code (`), and links ([text](url)) are not touched.
+ *
+ * Negative lookbehind/lookahead avoid false-positives on snake_case
+ * identifiers, hashtags, and asterisks inside tokens.
+ *
+ * Related: issue #222.
+ */
+export function stripMarkdownFormatting(text: string): string {
+  if (!text) return text;
+  return text
+    // **bold** and __bold__ first (greedy markers run before italic so
+    // we don't mis-handle e.g. "**foo**" as nested italic.
+    .replace(/\*\*([^*\n]+)\*\*/g, "“$1”")
+    .replace(/(?<!\w)__([^_\n]+)__(?!\w)/g, "“$1”")
+    // _italic_ — bounded by non-word chars to avoid snake_case.
+    .replace(/(?<!\w)_([^_\n]+)_(?!\w)/g, "“$1”")
+    // *italic* — same boundary rule.
+    .replace(/(?<!\w)\*([^*\n]+)\*(?!\w)/g, "“$1”");
+}


### PR DESCRIPTION
## Summary

Forward-fix for [#222](https://github.com/JuergenB/polywiz-app/issues/222). Generated post content was bleeding markdown italics (`_The Harbinger_`) into platforms that don't render markdown — Instagram, X, Facebook, Threads, Bluesky, Pinterest, and even LinkedIn for the underscore variant. Users saw literal underscores in published posts.

## Two-layer fix

1. **Prompt instruction** in [src/lib/prompts/blog-post-generator.ts](src/lib/prompts/blog-post-generator.ts) `<writing_style_requirements>` — explicitly forbids markdown formatting and points Claude at curly quotes (`"like this"`) for artwork titles, exhibition names, books, and creative works. Person names get no special formatting.

2. **Defensive post-processing sanitizer** at [src/lib/text-sanitizer.ts](src/lib/text-sanitizer.ts), applied at every Content write path. Scope is narrow — italic + bold only. Negative lookbehind/lookahead protect `snake_case` identifiers and `#some_tag` hashtags from false positives.

## Write paths covered

| Path | Sanitized | Notes |
|---|---|---|
| `POST /api/campaigns/[id]/generate` | yes | `Content` and `First Comment` fields, just before `createRecord("Posts", ...)` |
| `PATCH /api/posts/[id]` | yes | `Content` and `First Comment` — covers user paste-from-markdown case |
| `POST /api/posts/[id]/cover-slide-content` | yes | `campaignTypeLabel`, `headline`, `description` — these render onto images via Satori, so literal markdown chars would appear as text |
| `POST /api/quick-post` | n/a | Creates an empty post (`Content: ""`); generation runs through the campaign generate route which is already covered |

## Test results

13 unit tests in [src/lib/__tests__/text-sanitizer.test.ts](src/lib/__tests__/text-sanitizer.test.ts) cover italic, bold, mixed, snake_case (negative), hashtags (negative), empty string, null/undefined safety, idempotence on emojis, and pass-through of headings/inline-code/links.

Verified the real string from post `reccoOS13ot0rppmQ`:

| Input | Output |
|---|---|
| `Wesley Goatley's _The Harbinger_ is about what it hears.` | `Wesley Goatley's "The Harbinger" is about what it hears.` |
| `my_variable_name should be unchanged` | `my_variable_name should be unchanged` (no change) |
| `#some_tag should be unchanged` | `#some_tag should be unchanged` (no change) |
| `*emphasized*` | `"emphasized"` |
| `**The Harbinger**` | `"The Harbinger"` |

`npx tsc --noEmit` clean. Full vitest suite (46 tests) passes.

## Backfill

The backfill script for existing Pending + Approved posts is in a parallel branch ([feat/backfill-markdown-script](https://github.com/JuergenB/polywiz-app/tree/feat/backfill-markdown-script)). Scheduled posts deferred — they require Zernio `updatePost` coordination so the platform-side scheduled content stays in sync.

Closes [#222](https://github.com/JuergenB/polywiz-app/issues/222)

🤖 Generated with [Claude Code](https://claude.com/claude-code)